### PR TITLE
chore(oss): add MIT LICENSE, CODEOWNERS, and CONTRIBUTING

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# CODEOWNERS
+#
+# This file tells GitHub who is responsible for code in this repository.
+# The last matching pattern takes precedence. See:
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner(s) for everything in the repo
+* @FBakkensen
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+Contributing to al-build-tools
+================================
+
+Thanks for your interest in improving this project! This repository is a template for cross‑platform build tooling. Contributions are welcome from individuals and organizations.
+
+License and Contributor Terms
+-----------------------------
+- This project is licensed under the MIT License (see `LICENSE`).
+- By submitting a contribution (pull request, patch, or suggestion), you agree that your contribution will be licensed under the MIT License.
+
+How to Contribute
+-----------------
+- Fork the repo and create your feature branch from `main`.
+- Branch naming: use a short, descriptive prefix, e.g. `feat/…`, `fix/…`, `docs/…`, `chore/…`.
+- Make focused changes with small, reviewable commits. Reference issues in commit messages when applicable.
+- Open a pull request against `main` with:
+  - A clear description of motivation and changes.
+  - Any OS‑specific considerations (Linux/Windows) and manual verification notes.
+
+Development Guidelines
+----------------------
+- Cross‑platform parity: when adding a new task, provide both a Linux (`.sh`) and Windows (PowerShell, `.ps1`) implementation with the same behavior.
+- Do not break existing entry points under `overlay/` (see `AGENTS.md`).
+- Shell (Linux):
+  - Use `#!/usr/bin/env bash` and `set -euo pipefail`.
+  - Prefer portable Bash; check for required external tools and emit helpful errors.
+- PowerShell (Windows):
+  - Require PowerShell 7+ with `#requires -Version 7.0`.
+  - Use `Set-StrictMode -Version Latest` and `$ErrorActionPreference = 'Stop'`.
+- Logging & verbosity: support a `--verbose`/`VERBOSE` option mirrored across platforms.
+- JSON & config: reuse `overlay/scripts/make/*/lib/json-parser.*` helpers rather than duplicating parsing logic.
+
+Local Checks (Recommended)
+--------------------------
+- Linux:
+  - Run: `bash overlay/scripts/make/linux/show-analyzers.sh` to see recommended analyzers.
+  - If available, run `shellcheck` on new/changed `.sh` files.
+- Windows:
+  - Run: `pwsh -File overlay/scripts/make/windows/show-analyzers.ps1`.
+  - If available, run `PSScriptAnalyzer` on new/changed `.ps1` files.
+
+Line Endings and Encoding
+-------------------------
+- Use UTF‑8.
+- Shell scripts (`*.sh`) use LF; PowerShell scripts (`*.ps1`) use CRLF. See `.gitattributes` in `AGENTS.md` for guidance.
+
+Security & Dependencies
+-----------------------
+- Do not add network calls or new external dependencies without discussion.
+- If credentials are needed for a task, read them from environment variables and never commit secrets.
+
+Code Review
+-----------
+- Pull requests are reviewed by the code owners listed in `.github/CODEOWNERS`.
+- Address feedback promptly; keep changes small for faster review.
+
+Governance
+----------
+- For large changes or design proposals, open an issue first to discuss goals and approach.
+
+Thank you for contributing!
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 FBakkensen and the al-build-tools contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # AL Build Tools (overlay bootstrap)
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Contributions welcome](https://img.shields.io/badge/Contributions-welcome-brightgreen.svg)](CONTRIBUTING.md)
+
 A minimal, cross-platform build toolkit for Microsoft AL projects with a dead-simple bootstrap. It is designed to be dropped into an existing git repo and updated by running the same single command again.
 
 Install and update are the same: the bootstrap copies everything from this repo’s `overlay/` folder into your project. Because you’re in git, you review and commit changes as you like.
@@ -73,4 +76,8 @@ Only the contents of `overlay/` are ever copied to your project. That keeps the 
 
 ## Contributing
 
-Please keep Linux and Windows behavior in parity. When adding new tasks, update both `overlay/scripts/make/linux` and `overlay/scripts/make/windows`, and keep the Makefile thin.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow, cross‑platform parity rules, and analyzer tips. In short: keep Linux and Windows behavior in parity, update both `overlay/scripts/make/linux` and `overlay/scripts/make/windows`, and keep the Makefile thin.
+
+## License
+
+Licensed under the [MIT License](LICENSE). You are free to use, modify, and distribute this project with attribution and without warranty.


### PR DESCRIPTION
This PR adds:

- MIT LICENSE for broad use/modification
- .github/CODEOWNERS (default: @FBakkensen)
- CONTRIBUTING.md aligned with AGENTS.md cross-platform rules

Rationale: establish standard OSS hygiene and contributor guidance.

Verification: doc-only changes; no build logic modified.