### PR TITLE
ci(workflows): run static-analysis on every PR

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -2,9 +2,7 @@ name: Static Analysis Quality Gate
 
 on:
   pull_request:
-    paths:
-      - 'overlay/**'
-      - 'bootstrap/**'
+  workflow_dispatch:
 
 jobs:
   static-analysis:


### PR DESCRIPTION
This PR updates the static-analysis workflow to run on every pull_request and adds workflow_dispatch for manual runs. This makes the check 'Static Analysis Quality Gate / static-analysis' selectable as a required status check in rulesets across all PRs.