### PR TITLE
005-add-tests-for

### DIFF
--- a/.github/prompts/plan.prompt.md
+++ b/.github/prompts/plan.prompt.md
@@ -16,7 +16,7 @@ Given the implementation details provided as an argument, do this:
 4. Execute the implementation plan template:
    - Load `.specify/templates/plan-template.md` (already copied to IMPL_PLAN path)
    - Set Input path to FEATURE_SPEC
-   - Run the Execution Flow (main) function steps 1-10
+   - Run the Execution Flow (main) function steps 1-9
    - The template is self-contained and executable
    - Follow error handling and gate checks as specified
    - Let the template guide artifact generation in $SPECS_DIR:

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,48 +1,37 @@
 # AL Build Tools Constitution
 
-## Core Principles
+## Core Tenets
 
-### I. Parity (Cross-Platform Symmetry)
-Every Linux entry script has an exact PowerShell peer with the same name, contract, stdout shape, and exit semantics. A feature is incomplete unless both OS variants are implemented. Divergence in arguments, defaults, or output format is a defect.
+### 1. Cross-Platform Parity
+Every user-facing capability ships with Linux and Windows entry points that share names, arguments, exit semantics, and observable output. Launching a task on one platform must feel indistinguishable from the other. Shipping a feature on a single OS violates this charter.
 
-Clarification (2025-09-10): Feature spec 001 (static analysis quality gate) intentionally defers automated detection of missing cross-platform peers in its first phase. This deferral does NOT waive or weaken the Parity principle; maintainers must still ensure that any newly added task or entry script is introduced simultaneously for both Linux and Windows prior to merge. Future phases may add automated parity enforcement to complement, not redefine, this requirement.
+### 2. Repeatable Operations
+Build, clean, and inspection commands are safe to run repeatedly. They act only on declared artifacts, leave unrelated files untouched, and produce deterministic results. Automation and humans can rerun the toolkit without fear of drift.
 
-### II. Idempotence (Safe Re-Runs)
-All tasks can be executed repeatedly without corrupting state or requiring manual cleanup. Build and clean operations must deterministically recalculate outputs and only remove/replace artifacts they own. Pre-existing unrelated files are never touched.
+### 3. Workspace Purity
+Tooling honors the repository as the source of truth. Behavior derives strictly from checked-in files, supplied arguments, and explicit environment variables. No hidden caches, implicit configuration, or silent mutation of user files are permitted.
 
-### III. Zero Hidden State
-Tooling derives behavior solely from the workspace, explicit environment variables, and passed arguments. No opaque caches, no silently persisted config, no mutation of repository contents outside declared output paths. Temporary runtime artifacts stay out of version control.
+### 4. Transparent Contracts
+Published scripts emit clear status signals: documented exit codes, actionable errors routed to stderr, and stable stdout intended for chaining. Any change to those contracts requires deliberate versioning and communication before release.
 
-### IV. Discover Over Configure
-We auto-discover AL compiler, analyzers, and project metadata. User configuration is honored only when explicitly provided (e.g., `al.codeAnalyzers` list, environment overrides). No implicit enabling of analyzers or rulesets; absence means disabled.
+### 5. Overlay Minimalism
+The copied `overlay/` payload remains a thin, self-contained surface. Everything inside is treated as an external contract, stays free of internal coupling, avoids network access, and exposes only the entry points end users must invoke.
 
-### V. Minimal Entry Points & Shared Logic
-The `Makefile` and top-level scripts remain thin dispatch layers. Reusable behavior lives in shared `lib/` helpers (bash & PowerShell mirrors). New functionality prefers extension of shared helpers over duplication. Safety guardrails (path validation, destructive action checks) are mandatory before invoking compiler or deleting artifacts.
+## Non-Negotiable Guardrails
+- **Security First**: Secrets are never embedded; credentials flow only through environment variables or tooling already managed by users.
+- **Environment Isolation**: Child processes must not leak or overwrite caller environment state. Any temporary context stays process-scoped or lives under disposable directories.
+- **Deterministic Artifacts**: Output names, locations, and cleanup rules are predictable and reversible. Artifacts belong under the target app directory, with collisions resolved safely.
+- **Analyzer Discipline**: Analyzers run only when explicitly configured. Discovery favors reporting over guessing; absence of configuration means analyzers stay disabled.
+- **Safety Checks**: Scripts validate paths and inputs before deleting files or invoking compilers. Guard clauses prevent destructive operations outside the app boundary.
 
-## Operational Constraints & Boundaries
-1. Overlay Integrity: Only the `overlay/` directory is shipped to consuming projects; all other repository content supports its evolution and must not introduce runtime coupling.
-2. No Relocation: Do not rename or move published entry scripts or bootstrap installers; stability for downstream automation is paramount.
-3. Generic Scope: Prohibit business/customer-specific logic; overlay must remain applicable to any AL project.
-4. Security & Secrets: Read secrets exclusively from environment variables; never hardcode credentials or tokens.
-5. Style Enforcement: Bash uses `set -euo pipefail`; PowerShell uses strict mode and explicit `param()` blocks. Filenames are kebab-case; logic is function-scoped.
-6. Analyzer Handling: Only resolvable analyzers explicitly configured are executed; unresolved tokens trigger clear errors, not silent fallback.
-7. Deterministic Outputs: Output package name pattern `${publisher}_${name}_${version}.app` is mandatory; pre-existing conflicting files are removed safely before creation.
-8. Architecture Awareness: Compiler resolution must handle architecture-specific folders with graceful fallback to legacy locations.
-9. No Silent Mutation: Scripts never rewrite project configuration files (e.g., `.vscode/settings.json`); inspection tasks are read-only.
-
-## Development Workflow & Quality Gates
-1. Feature Inception: New functionality begins with a spec (feature number + directory) generated via automation scripts; plans and task tracking follow.
-2. Branch Naming: Use scripted generation (`scripts/create-new-feature.sh`) ensuring consistent numeric prefix for ordering & traceability.
-3. Change Scope: Pull requests are surgical—only modify files directly supporting the stated feature or fix. Unrelated refactors are deferred.
-4. Testing Requirements: Run build & clean twice on both OS variants; confirm idempotence and absence of residual or orphan artifacts. Validate analyzer resolution output when analyzers are configured.
-5. Review Checklist: Parity achieved, no hidden state introduced, discovery rules preserved, minimal entry points unchanged, helper reuse evaluated.
-6. Failure Transparency: All errors are directed to stderr with actionable, single-line summaries; multi-line diagnostics only when necessary.
-7. Version Discipline: Tooling changes that alter external contract (arguments, output format, file layout) require a documented rationale and potential migration notes.
-8. Pitfall Avoidance: Explicitly verify no addition of default analyzers, no temp files added inside `overlay/`, and no drift between Linux/Windows implementations.
-9. Automation Sync: After significant structural updates, regenerate AI instruction contexts using the provided update script to keep agent guidance current.
-10. Documentation Currency: New tasks or flags require updating relevant guidance (`AGENTS.md`, `.github/copilot-instructions.md`) in the same PR.
+## Delivery Discipline
+1. **Spec Before Build**: Significant work begins with a numbered spec describing motivation, scope, parity expectations, and verification strategy.
+2. **Focused Changes**: Contributions touch only the files required for the stated objective. Opportunistic refactors or feature creep are deferred.
+3. **Symmetric Testing**: Contributors validate Linux and Windows flows, including double-run idempotence, before declaring a change complete.
+4. **Documentation in Lockstep**: Any new flag, behavior, or contract adjustment updates user guidance and agent instructions in the same change set.
+5. **Observable Failures**: Errors are concise, single-line summaries with optional diagnostics beneath. Success paths are equally explicit about what occurred.
 
 ## Governance
-This Constitution supersedes ancillary style notes where conflicts arise. Compliance is a mandatory review gate; PRs that violate any core principle must be revised before merge. Amendments require: (a) explicit motivation, (b) impact analysis (including downstream repos), (c) parity considerations, and (d) versioning / migration guidance if external contracts change. Consensus of maintainers plus documented approval in the PR description is required. Emergency fixes may merge ahead of documentation only when resolving breakage; documentation and (if needed) constitutional amendments must follow immediately.
+This Constitution outranks ancillary notes when conflicts arise. Amending a tenet or guardrail demands: clear motivation, downstream impact analysis, parity verification, and documented maintainer approval. Emergency fixes may bypass documentation only to stop an active regression; remediation notes and (if needed) constitutional updates follow immediately.
 
-**Version**: 1.0.1 | **Ratified**: 2025-09-10 | **Last Amended**: 2025-09-10
+**Version**: 1.1.0 | **Ratified**: 2025-09-10 | **Last Amended**: 2025-09-16

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -1,5 +1,5 @@
-# Implementation Plan: [FEATURE]
 
+# Implementation Plan: [FEATURE]
 
 **Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
 **Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
@@ -11,18 +11,19 @@
 2. Fill Technical Context (scan for NEEDS CLARIFICATION)
    → Detect Project Type from context (web=frontend+backend, mobile=app+api)
    → Set Structure Decision based on project type
-3. Evaluate Constitution Check section below
+3. Fill the Constitution Check section based on the content of the constitution document.
+4. Evaluate Constitution Check section below
    → If violations exist: Document in Complexity Tracking
    → If no justification possible: ERROR "Simplify approach first"
    → Update Progress Tracking: Initial Constitution Check
-4. Execute Phase 0 → research.md
+5. Execute Phase 0 → research.md
    → If NEEDS CLARIFICATION remain: ERROR "Resolve unknowns"
-5. Execute Phase 1 → contracts, data-model.md, quickstart.md, agent-specific template file (e.g., `CLAUDE.md` for Claude Code, `.github/copilot-instructions.md` for GitHub Copilot, or `GEMINI.md` for Gemini CLI).
-6. Re-evaluate Constitution Check section
+6. Execute Phase 1 → contracts, data-model.md, quickstart.md, agent-specific template file (e.g., `CLAUDE.md` for Claude Code, `.github/copilot-instructions.md` for GitHub Copilot, or `GEMINI.md` for Gemini CLI).
+7. Re-evaluate Constitution Check section
    → If new violations: Refactor design, return to Phase 1
    → Update Progress Tracking: Post-Design Constitution Check
-7. Plan Phase 2 → Describe task generation approach (DO NOT create tasks.md)
-8. STOP - Ready for /tasks command
+8. Plan Phase 2 → Describe task generation approach (DO NOT create tasks.md)
+9. STOP - Ready for /tasks command
 ```
 
 **IMPORTANT**: The /plan command STOPS at step 7. Phases 2-4 are executed by other commands:
@@ -46,35 +47,7 @@
 ## Constitution Check
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-**Simplicity**:
-- Projects: [#] (max 3 - e.g., api, cli, tests)
-- Using framework directly? (no wrapper classes)
-- Single data model? (no DTOs unless serialization differs)
-- Avoiding patterns? (no Repository/UoW without proven need)
-
-**Architecture**:
-- EVERY feature as library? (no direct app code)
-- Libraries listed: [name + purpose for each]
-- CLI per library: [commands with --help/--version/--format]
-- Library docs: llms.txt format planned?
-
-**Testing (NON-NEGOTIABLE)**:
-- RED-GREEN-Refactor cycle enforced? (test MUST fail first)
-- Git commits show tests before implementation?
-- Order: Contract→Integration→E2E→Unit strictly followed?
-- Real dependencies used? (actual DBs, not mocks)
-- Integration tests for: new libraries, contract changes, shared schemas?
-- FORBIDDEN: Implementation before test, skipping RED phase
-
-**Observability**:
-- Structured logging included?
-- Frontend logs → backend? (unified stream)
-- Error context sufficient?
-
-**Versioning**:
-- Version number assigned? (MAJOR.MINOR.BUILD)
-- BUILD increments on every change?
-- Breaking changes handled? (parallel tests, migration plan)
+[Gates determined based on constitution file]
 
 ## Project Structure
 
@@ -172,7 +145,7 @@ ios/ or android/
    - Quickstart test = story validation steps
 
 5. **Update agent file incrementally** (O(1) operation):
-   - Run `/scripts/powershell/update-agent-context.ps1 -AgentType copilot` for your AI assistant
+   - Run `.specify/scripts/powershell/update-agent-context.ps1 -AgentType copilot` for your AI assistant
    - If exists: Add only NEW tech from current plan
    - Preserve manual additions between markers
    - Update recent changes (keep last 3)
@@ -185,7 +158,7 @@ ios/ or android/
 *This section describes what the /tasks command will do - DO NOT execute during /plan*
 
 **Task Generation Strategy**:
-- Load `/templates/tasks-template.md` as base
+- Load `.specify/templates/tasks-template.md` as base
 - Generate tasks from Phase 1 design docs (contracts, data model, quickstart)
 - Each contract → contract test task [P]
 - Each entity → model creation task [P] 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,19 @@ When contributing: If you are about to add a new file under `overlay/`, ask: (a)
 ## Security & Configuration Tips
 - Never hardcode secrets; read from environment variables. On Windows, use `-ExecutionPolicy Bypass` only for one-off local runs.
 
+## ⚠️ CRITICAL: Repository Safety Warning
+**NEVER run `bootstrap/install.ps1` directly in this repository.** 
+
+Running the installer in the source repository will:
+- Pollute the working directory with overlay files
+- Create untracked files that interfere with git operations
+- Potentially overwrite local development files
+- Make the repository dirty and complicate testing
+
+**Safe alternatives:**
+- Use the test harness in `tests/` directory which creates isolated workspaces
+- Run installer in a separate, disposable test directory
+- Use the archive server test utilities that provide controlled environments
+
+The installer is designed to be run in **consumer repositories**, not in the development repository.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,5 +55,3 @@ When contributing: If you are about to add a new file under `overlay/`, ask: (a)
 ## Security & Configuration Tips
 - Never hardcode secrets; read from environment variables. On Windows, use `-ExecutionPolicy Bypass` only for one-off local runs.
 
-## Agent Behavior (Codex CLI)
-- Do not run repository-changing Git operations or create PRs without explicit user instruction. Follow the paths/commands above and ask when uncertain.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ The repository includes Pester tests for contract behavior and integration flows
   - `Invoke-Pester -CI -Path tests/contract`
   - `Invoke-Pester -CI -Path tests/integration`
 
+### Installer Test Contract
+
+The installer contract (FR-012) documents the behaviors enforced by the automated suites so contributors know what must remain stable:
+
+- Guard rails: rejects non-git destinations, dirty working trees, unsupported PowerShell, unknown parameters, and restricted/denied writes. Each failure emits `[install] guard <Reason>` and exits 10 (guards) or 30 (permission scope); tests assert these diagnostics.
+- Temp workspace: emits `[install] temp workspace="..."`, which must live under the system temp root and be cleaned up after every run.
+- Download diagnostics: acquisition failures log `[install] download failure ... category=<NetworkUnavailable|NotFound|CorruptArchive|Timeout|Unknown>` and must leave the destination unchanged.
+- Success path: success logs `[install] success ref="..." overlay="..." duration=<seconds>` and a second run must restore overlay file hashes (idempotence).
+- Step telemetry: `[install] step index=... name=...` stays stable to keep parity and performance checks meaningful across platforms.
+
+Run `pwsh -File scripts/run-tests.ps1 -CI` before modifying `bootstrap/install.ps1`; CI replays the same contract on Windows and Ubuntu.
+
 ## How It Works
 
 1. Downloads a ZIP of this repo at the specified ref (default `main`).

--- a/README.md
+++ b/README.md
@@ -100,15 +100,19 @@ The repository includes Pester tests for contract behavior and integration flows
 
 ### Installer Test Contract
 
-The installer contract (FR-012) documents the behaviors enforced by the automated suites so contributors know what must remain stable:
+The installer contract (FR-012) documents the behaviors enforced by the automated suites so contributors know what must remain stable. Coverage lives in:
+- `tests/contract/Install.*.Tests.ps1` — guard rails and download diagnostics (FR-003, FR-004, FR-008, FR-014, FR-015, FR-020, FR-023, FR-024).
+- `tests/integration/Install.*.Tests.ps1` — success, idempotence, parity, and performance flows (FR-001, FR-002, FR-005, FR-006, FR-010, FR-017-FR-019, FR-022, FR-025).
+- `tests/_install/Assert-Install.psm1` — shared helpers that lock diagnostic formats and hash verification (FR-009, FR-021).
 
-- Guard rails: rejects non-git destinations, dirty working trees, unsupported PowerShell, unknown parameters, and restricted/denied writes. Each failure emits `[install] guard <Reason>` and exits 10 (guards) or 30 (permission scope); tests assert these diagnostics.
+Key expectations that must stay stable:
+- Guard rails: rejects non-git destinations, dirty working trees, unsupported PowerShell, unknown parameters, and restricted/denied writes. Each failure emits `[install] guard <Reason>` and exits 10 (guards) or 30 (permission scope).
+- Download diagnostics: acquisition failures log a single `[install] download failure ... category=<NetworkUnavailable|NotFound|CorruptArchive|Timeout|Unknown>` line, exit 20, and must leave the destination unchanged.
 - Temp workspace: emits `[install] temp workspace="..."`, which must live under the system temp root and be cleaned up after every run.
-- Download diagnostics: acquisition failures log `[install] download failure ... category=<NetworkUnavailable|NotFound|CorruptArchive|Timeout|Unknown>` and must leave the destination unchanged.
 - Success path: success logs `[install] success ref="..." overlay="..." duration=<seconds>` and a second run must restore overlay file hashes (idempotence).
 - Step telemetry: `[install] step index=... name=...` stays stable to keep parity and performance checks meaningful across platforms.
 
-Run `pwsh -File scripts/run-tests.ps1 -CI` before modifying `bootstrap/install.ps1`; CI replays the same contract on Windows and Ubuntu.
+When updating `bootstrap/install.ps1`, adjust `specs/005-add-tests-for/traceability.md` if coverage moves and run `pwsh -File scripts/run-tests.ps1 -CI`; CI replays the same contract on Windows and Ubuntu.
 
 ## How It Works
 

--- a/bootstrap/install.ps1
+++ b/bootstrap/install.ps1
@@ -8,6 +8,15 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# Check for unknown parameters by inspecting command line arguments
+if ($args.Count -gt 0) {
+    $firstArg = $args[0]
+    $argName = if ($firstArg.StartsWith('-')) { $firstArg.Substring(1) } else { $firstArg }
+    Write-Host "[install] guard UnknownParameter argument=`"$argName`""
+    Write-Host "Usage: Install-AlBuildTools [-Url <url>] [-Ref <ref>] [-Dest <path>] [-Source <folder>]"
+    throw "Unknown parameter: $firstArg"
+}
+
 function Write-Note($msg) { Write-Host "[al-build-tools] $msg" -ForegroundColor Cyan }
 function Write-Ok($msg)   { Write-Host "[ok] $msg" -ForegroundColor Green }
 function Write-Warn2($m)  { Write-Warning $m }
@@ -22,6 +31,13 @@ function Install-AlBuildTools {
         [string]$Source = 'overlay'
     )
 
+    # Check PowerShell version requirement
+    if ($PSVersionTable.PSVersion -lt [System.Version]'7.0') {
+        Write-Host "[install] guard PowerShellVersionUnsupported"
+        throw "PowerShell 7.0 or higher required. Current version: $($PSVersionTable.PSVersion)"
+    }
+
+    $startTime = Get-Date
     $step = 0
     $step++; Write-Step $step "Resolve destination"
     try {
@@ -49,11 +65,36 @@ function Install-AlBuildTools {
         Write-Verbose "[install] git check failed: $($_.Exception.Message)"
     }
     if (-not $gitOk -and -not (Test-Path (Join-Path $destFull '.git'))) {
-        Write-Warn2 "Destination '$destFull' does not look like a git repo. Proceeding anyway."
+        Write-Host "[install] guard GitRepoRequired"
+        throw "Installation requires a git repository. Initialize with 'git init' first."
+    }
+    
+    # Check working tree cleanliness if this is a git repo
+    if ($gitOk -or (Test-Path (Join-Path $destFull '.git'))) {
+        try {
+            $pinfo = New-Object System.Diagnostics.ProcessStartInfo
+            $pinfo.FileName = 'git'
+            $pinfo.Arguments = "-C `"$destFull`" status --porcelain"
+            $pinfo.RedirectStandardOutput = $true
+            $pinfo.RedirectStandardError = $true
+            $pinfo.UseShellExecute = $false
+            $p = [System.Diagnostics.Process]::Start($pinfo)
+            $p.WaitForExit()
+            if ($p.ExitCode -eq 0) {
+                $statusOutput = $p.StandardOutput.ReadToEnd().Trim()
+                if (-not [string]::IsNullOrEmpty($statusOutput)) {
+                    Write-Host "[install] guard WorkingTreeNotClean"
+                    throw "Working tree must be clean. Commit or stash changes first."
+                }
+            }
+        } catch {
+            Write-Verbose "[install] working tree check failed: $($_.Exception.Message)"
+        }
     }
     Write-Ok "Working in: $destFull"
 
     $tmp = New-Item -ItemType Directory -Path ([System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName()))
+    Write-Host "[install] temp workspace=`"$($tmp.FullName)`""
     try {
         $step++; Write-Step $step "Download repository archive"
         $zip = Join-Path $tmp.FullName 'src.zip'
@@ -65,6 +106,7 @@ function Install-AlBuildTools {
         )
 
         $downloaded = $false
+        $lastError = $null
         foreach ($u in $tryUrls) {
             try {
                 Write-Note "Downloading: $u"
@@ -72,32 +114,94 @@ function Install-AlBuildTools {
                 $downloaded = $true
                 break
             } catch {
+                $lastError = $_
                 continue
             }
         }
         if (-not $downloaded) {
+            # Classify the download failure
+            $category = 'Unknown'
+            $hint = 'Check network connectivity and repository URL'
+            if ($lastError) {
+                $errorMessage = $lastError.Exception.Message.ToLower()
+                if ($errorMessage -match 'network|connection|timeout|unreachable') {
+                    $category = 'NetworkUnavailable'
+                    $hint = 'Network connectivity issues'
+                } elseif ($errorMessage -match '404|not found') {
+                    $category = 'NotFound'
+                    $hint = 'Repository or reference does not exist'
+                } elseif ($errorMessage -match 'timeout') {
+                    $category = 'Timeout'
+                    $hint = 'Request timed out'
+                } elseif ($errorMessage -match 'corrupt|invalid|archive') {
+                    $category = 'CorruptArchive'
+                    $hint = 'Archive file is corrupted or invalid'
+                }
+            }
+            Write-Host "[install] download failure ref=`"$Ref`" url=`"$base`" category=$category hint=`"$hint`""
             throw "Failed to download repo archive for ref '$Ref' from $Url."
         }
 
         $step++; Write-Step $step "Extract and locate '$Source'"
         $extract = Join-Path $tmp.FullName 'x'
-        Expand-Archive -LiteralPath $zip -DestinationPath $extract -Force
+        try {
+            Expand-Archive -LiteralPath $zip -DestinationPath $extract -Force -ErrorAction Stop
+        } catch {
+            Write-Host "[install] download failure ref=`"$Ref`" url=`"$base`" category=CorruptArchive hint=`"Failed to extract archive`""
+            throw "Failed to extract archive: $($_.Exception.Message)"
+        }
         $top = Get-ChildItem -Path $extract -Directory | Select-Object -First 1
-        if (-not $top) { throw 'Archive appears empty or unreadable.' }
+        if (-not $top) { 
+            Write-Host "[install] download failure ref=`"$Ref`" url=`"$base`" category=CorruptArchive hint=`"Archive appears empty`""
+            throw 'Archive appears empty or unreadable.' 
+        }
         $src = Join-Path $top.FullName $Source
         if (-not (Test-Path $src -PathType Container)) {
             # last-chance scan
             $cand = Get-ChildItem -Path $extract -Recurse -Directory -Filter $Source | Select-Object -First 1
-            if ($cand) { $src = $cand.FullName } else { throw "Expected subfolder '$Source' not found in archive at ref '$Ref'." }
+            if ($cand) { 
+                $src = $cand.FullName 
+            } else { 
+                Write-Host "[install] download failure ref=`"$Ref`" url=`"$base`" category=NotFound hint=`"Source folder '$Source' not found in archive`""
+                throw "Expected subfolder '$Source' not found in archive at ref '$Ref'." 
+            }
         }
+        
+        # Validate extraction completed successfully before proceeding
+        if (-not (Get-ChildItem -Path $src -File -ErrorAction SilentlyContinue)) {
+            Write-Host "[install] download failure ref=`"$Ref`" url=`"$base`" category=CorruptArchive hint=`"Source directory contains no files`""
+            throw "Source directory '$src' contains no files."
+        }
+        
         Write-Ok "Source directory: $src"
 
         $step++; Write-Step $step "Copy files into destination"
+        
+        # Verify all source files would stay within destination boundary
+        $overlayFiles = Get-ChildItem -Path $src -Recurse -File
+        foreach ($file in $overlayFiles) {
+            $relativePath = $file.FullName.Substring($src.Length).TrimStart('\', '/')
+            $targetPath = Join-Path $destFull $relativePath
+            $resolvedTarget = [System.IO.Path]::GetFullPath($targetPath)
+            if (-not $resolvedTarget.StartsWith($destFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+                Write-Host "[install] guard RestrictedWrites"
+                throw "File '$relativePath' would write outside destination scope."
+            }
+        }
+        
         $fileCount = (Get-ChildItem -Path $src -Recurse -File | Measure-Object).Count
         $dirCount  = (Get-ChildItem -Path $src -Recurse -Directory | Measure-Object).Count + 1
-        Copy-Item -Path (Join-Path $src '*') -Destination $destFull -Recurse -Force
+        try {
+            Copy-Item -Path (Join-Path $src '*') -Destination $destFull -Recurse -Force -ErrorAction Stop
+        } catch [System.UnauthorizedAccessException], [System.IO.IOException] {
+            Write-Host "[install] guard PermissionDenied"
+            throw "Permission denied copying to destination. Check write access to '$destFull'."
+        }
         Write-Ok "Copied $fileCount files across $dirCount directories"
 
+        $endTime = Get-Date
+        $durationSeconds = ($endTime - $startTime).TotalSeconds
+        Write-Host "[install] success ref=`"$Ref`" overlay=`"$Source`" duration=$($durationSeconds.ToString('F2', [System.Globalization.CultureInfo]::InvariantCulture))"
         Write-Note "Completed: $Source from $Url@$Ref into $destFull"
     } finally {
         try { Remove-Item -Recurse -Force -LiteralPath $tmp.FullName -ErrorAction SilentlyContinue } catch { Write-Verbose "[install] cleanup failed: $($_.Exception.Message)" }

--- a/specs/005-add-tests-for/contracts/README.md
+++ b/specs/005-add-tests-for/contracts/README.md
@@ -7,16 +7,16 @@ Although no network API is exposed, the installer publishes observable contracts
 - Download failure: `[install] download failure ref=<ref> url=<url> category=<CategoryName> hint=<hint>`
 - Guard rail failures include stable prefix `[install] guard` followed by reason category token (e.g., `GitRepoRequired`, `WorkingTreeNotClean`, `PowerShellVersionUnsupported`).
 
-## Exit Codes (Proposed for Test Alignment)
-| Scenario | Exit Code |
-|----------|-----------|
-| Success | 0 |
-| Guard rail failure | 10 |
-| Download failure | 20 |
-| Permission/IO failure | 30 |
-| Unknown/unhandled failure | 99 |
+## Exit Codes (Current Behavior)
+| Scenario | Exit Code | Notes |
+|----------|-----------|-------|
+| Success | 0 | Normal completion; overlay copied successfully. |
+| Guard rail failure (preconditions/arguments) | 10 | e.g., `GitRepoRequired`, `WorkingTreeNotClean`, `PowerShellVersionUnsupported`, `UnknownParameter`. |
+| Download failure | 20 | Includes `NetworkUnavailable`, `NotFound`, `CorruptArchive`, `Timeout`, `Unknown` acquisition categories. |
+| Permission/IO failure | 30 | Raised for guard lines such as `RestrictedWrites` and `PermissionDenied` when the filesystem blocks writes. |
+| Unknown/unhandled failure | 99 | Top-level catch-all from the autorun exception handler. |
 
-(If current implementation differs, align tests to actual codes and update this table.)
+Tests under `tests/contract` and `tests/integration` assert these exit codes; update docs and tests together when behavior changes.
 
 ## Overwrite Semantics
 - Second execution must fully replace all files under overlay path with fresh ref content regardless of prior modifications.

--- a/specs/005-add-tests-for/contracts/README.md
+++ b/specs/005-add-tests-for/contracts/README.md
@@ -1,0 +1,28 @@
+# Behavioral Contracts: install.ps1
+
+Although no network API is exposed, the installer publishes observable contracts enforced by tests.
+
+## Diagnostic Line Formats
+- Success summary (example): `[install] success ref=<ref> overlay=<path> duration=<seconds>`
+- Download failure: `[install] download failure ref=<ref> url=<url> category=<CategoryName> hint=<hint>`
+- Guard rail failures include stable prefix `[install] guard` followed by reason category token (e.g., `GitRepoRequired`, `WorkingTreeNotClean`, `PowerShellVersionUnsupported`).
+
+## Exit Codes (Proposed for Test Alignment)
+| Scenario | Exit Code |
+|----------|-----------|
+| Success | 0 |
+| Guard rail failure | 10 |
+| Download failure | 20 |
+| Permission/IO failure | 30 |
+| Unknown/unhandled failure | 99 |
+
+(If current implementation differs, align tests to actual codes and update this table.)
+
+## Overwrite Semantics
+- Second execution must fully replace all files under overlay path with fresh ref content regardless of prior modifications.
+
+## Temp Workspace
+- Created under system temp (`[install] temp <path>` optional log line recommended for test discovery) and removed before exit.
+
+## Non-Goals
+- No caching, diff detection, or partial updates.

--- a/specs/005-add-tests-for/data-model.md
+++ b/specs/005-add-tests-for/data-model.md
@@ -1,0 +1,54 @@
+# Data Model (Conceptual for Test Traceability)
+
+## Entities
+
+### InstallerSession
+- Fields:
+  - ref (string) - source git ref used for overlay
+  - startTime (datetime)
+  - endTime (datetime)
+  - tempWorkspacePath (string)
+  - exitCode (int)
+  - outcome (enum: Success|Failure)
+  - failureCategory (enum per FR-014) optional
+  - diagnostics (string[])
+- Relationships: 1-to-many with DownloadAttempt; 1-to-many with GuardRailOutcome
+
+### DownloadAttempt
+- Fields:
+  - url (string)
+  - timestamp (datetime)
+  - result (enum: Success|Failure)
+  - category (enum per FR-014)
+  - hint (string)
+
+### GuardRailOutcome
+- Fields:
+  - name (string) e.g., PowerShellVersion, CleanGitState, GitRepoPresent
+  - passed (bool)
+  - message (string)
+
+## Derived Test Assertions Mapping
+| Requirement | Entity Focus | Assertion Strategy |
+|-------------|--------------|--------------------|
+| FR-001 | InstallerSession | Successful outcome, temp workspace ephemeral |
+| FR-002 / FR-025 | InstallerSession | Hash comparison before/after second run |
+| FR-003 / FR-004 | GuardRailOutcome | Specific guard fails with message |
+| FR-005 | InstallerSession | No overlay files when failure pre-copy |
+| FR-006 | InstallerSession | Expected overlay artifacts exist post success |
+| FR-007 | GuardRailOutcome | No writes outside overlay path |
+| FR-008 | GuardRailOutcome | Unknown parameter rejected |
+| FR-009 | InstallerSession | Diagnostic lines stable patterns |
+| FR-010 | InstallerSession | Execution duration < 30s |
+| FR-011 | InstallerSession | Independent fresh git working trees |
+| FR-012 | (Documentation) | Quickstart maps scenarios -> tests |
+| FR-013 | (Traceability) | This table + tasks mapping |
+| FR-014 | DownloadAttempt | Single-line diagnostic pattern |
+| FR-015 | GuardRailOutcome | Re-run blocked when dirty after partial failure |
+| FR-016-018 | InstallerSession | Parity tests both OSes |
+| FR-019 | InstallerSession | Temp workspace created & removed |
+| FR-020 | GuardRailOutcome | Permission failure captured |
+| FR-021 | Testing Harness | Shared assertions no OS branching |
+| FR-022 | Testing Harness | Single suite pass implies parity |
+| FR-023 | GuardRailOutcome | Non-git path abort |
+| FR-024 | GuardRailOutcome | Dirty git state abort |

--- a/specs/005-add-tests-for/plan.md
+++ b/specs/005-add-tests-for/plan.md
@@ -1,0 +1,73 @@
+# Implementation Plan: Add Automated Tests for install.ps1
+
+**Branch**: `005-add-tests-for` | **Date**: 2025-09-16 | **Spec**: specs/005-add-tests-for/spec.md
+**Input**: Feature specification from `/specs/005-add-tests-for/spec.md`
+
+## Summary
+Add comprehensive cross-platform automated tests (Pester) validating bootstrap installer (`install.ps1`) reliability, guard rails, deterministic overwrite, diagnostic stability, and failure category reporting without expanding overlay public surface.
+
+## Technical Context
+**Language/Version**: PowerShell 7+ (tests), minimal shell usage
+**Primary Dependencies**: Git, PowerShell, Pester (existing test framework)
+**Storage**: N/A
+**Testing**: Pester integration + contract style (mirrors existing `tests/contract` & `tests/integration` organization)
+**Target Platform**: Windows + Ubuntu (parity required)
+**Project Type**: Single toolkit repository
+**Performance Goals**: Successful default run <30s (FR-010)
+**Constraints**: No network dependency beyond required GitHub ref download; overlay ephemeral; no added runtime dependencies
+**Scale/Scope**: Single script behavioral contract; ~25 requirements traced
+
+## Constitution Check (Initial)
+Simplicity: Single project; no new frameworks; direct use of Pester.
+Architecture: No new libraries; tests only.
+Testing: RED-GREEN to be followed when adding failing tests first for any new installer diagnostic adjustments.
+Observability: Structured single-line diagnostics specified.
+Versioning: Behavioral contract documented in contracts README.
+Result: PASS (no deviations)
+
+## Phase 0: Research Output
+See `research.md` for decisions on temp workspace detection, performance thresholds, idempotence verification, failure diagnostics, permission simulation, and parity strategies. All unknowns resolved.
+
+## Phase 1: Design Output
+Artifacts generated:
+- `research.md`
+- `data-model.md`
+- `contracts/README.md`
+- `quickstart.md`
+Traceability table in data-model maps FR-001..FR-025.
+
+## Phase 2: Task Planning Approach
+Outlined (to be materialized in `tasks.md` later):
+- Derive one test task per functional requirement cluster (group similar FRs: guard rails, overwrite, parity, diagnostics, performance).
+- Include setup helpers for: temp workspace capture, file hashing, dirty repo simulation.
+- Mark parity verification tasks parallelizable.
+- Ensure initial commit introduces failing tests for any not-yet-implemented diagnostics (e.g., standardized `[install] download failure` format if not present).
+
+Ordering:
+1. Guard rail failure tests (fail fast scenarios)
+2. Success path + idempotent overwrite
+3. Failure categories (network simulation stubs/mocks via invalid refs, set hosts file scenario if needed)
+4. Temp workspace lifecycle
+5. Performance threshold measurement
+6. Parity + structural comparison
+
+## Complexity Tracking
+None.
+
+## Progress Tracking
+**Phase Status**:
+- [x] Phase 0: Research complete (/plan command)
+- [x] Phase 1: Design complete (/plan command)
+- [ ] Phase 2: Task planning complete (/plan command - describe approach only)
+- [ ] Phase 3: Tasks generated (/tasks command)
+- [ ] Phase 4: Implementation complete
+- [ ] Phase 5: Validation passed
+
+**Gate Status**:
+- [x] Initial Constitution Check: PASS
+- [x] Post-Design Constitution Check: PASS
+- [x] All NEEDS CLARIFICATION resolved
+- [ ] Complexity deviations documented
+
+---
+Based on Constitution v1.1.0

--- a/specs/005-add-tests-for/quickstart.md
+++ b/specs/005-add-tests-for/quickstart.md
@@ -1,0 +1,39 @@
+# Quickstart: Validating install.ps1 Behavior
+
+## Prerequisites
+- PowerShell 7+
+- Git installed and in PATH
+
+## Steps (Windows or Ubuntu)
+```pwsh
+# 1. Clone a clean copy
+git clone https://github.com/FBakkensen/al-build-tools demo-install-test
+cd demo-install-test
+
+# 2. Run installer (default)
+pwsh -File bootstrap/install.ps1
+
+# 3. Re-run to verify overwrite idempotence
+pwsh -File bootstrap/install.ps1
+
+# 4. Introduce dirty state (expect failure)
+Set-Content overlay/TEST-DIRTY.txt 'local change'
+pwsh -File bootstrap/install.ps1 # should abort due to non-clean working tree
+
+# 5. Simulate missing git repo (expect failure)
+mkdir ..\no-git
+Copy-Item -Recurse * ..\no-git
+cd ..\no-git
+pwsh -File bootstrap/install.ps1 # should abort (no .git)
+```
+
+## Expected Outcomes
+- Two successful runs with identical success summaries.
+- Third run aborts with guidance about cleaning working tree.
+- Non-git directory run aborts with guidance about initializing git repository.
+
+## Performance Check
+Execution time for a default run should be <30s (network dependent). Use `Measure-Command` locally if concerned about regressions.
+
+## Parity Confirmation
+Run the same steps in Ubuntu shell (`pwsh`) with only path differences; outputs must be structurally comparable.

--- a/specs/005-add-tests-for/research.md
+++ b/specs/005-add-tests-for/research.md
@@ -1,0 +1,65 @@
+# Research: Test Strategy for install.ps1
+
+## Decisions
+
+### Test Framework & Execution
+- Decision: Use existing Pester-based test structure (contract + integration) mirroring current tests under `tests/`.
+- Rationale: Maintains repository consistency; no new dependency; aligns with constitutional parity & repeatability.
+- Alternatives: Introduce separate bootstrap test harness – rejected (added complexity, violates minimal surface & simplicity tenet).
+
+### Cross-Platform Strategy
+- Decision: Reuse existing CI matrix (Windows + Ubuntu) and ensure new tests are OS-agnostic by normalizing path assertions.
+- Rationale: Constitution requires parity; simpler than branching logic.
+- Alternatives: Separate OS-specific test files – rejected (duplication risk, divergence).
+
+### Temporary Workspace Detection
+- Decision: Capture installer transcript; parse logged temp path (require stable prefix `[install] temp` to be added if missing in implementation scope).
+- Rationale: Enables asserting creation & cleanup without internal coupling.
+- Alternatives: Environment variable injection – rejected (would expand public surface & encourage implicit config; constitution discourages hidden knobs).
+
+### Failure Category Assertions (FR-014)
+- Decision: Pattern match single-line diagnostic with anchored regex: `^\[install] download failure ref=.+ url=.+ category=(NetworkUnavailable|NotFound|CorruptArchive|Timeout|Unknown) hint=.+$`.
+- Rationale: Stable, explicit; resilient to ordering changes in other output.
+- Alternatives: Multi-line JSON diagnostic – rejected (increases verbosity, no current need).
+
+### Performance Budget (FR-010)
+- Decision: Soft threshold <30s enforced via measuring elapsed time in integration test; test warns (Assert-Verifiable) if >25s and fails if ≥30s.
+- Rationale: Early regression signal while allowing minor variance.
+- Alternatives: No timing – rejected (requirement explicit); strict <25s fail – rejected (risk of flaky CI on cold network).
+
+### Working Tree Cleanliness Detection
+- Decision: Reuse `git status --porcelain=v1` in test harness to introduce modifications/untracked files and assert non-zero exit + guidance phrase.
+- Rationale: Black-box: does not rely on implementation internals; replicates user scenario.
+
+### Idempotent Overwrite Verification
+- Decision: First run: record file hashes under overlay path. Modify a file inside overlay manually. Second run: assert modified file restored to original content and all hashes realign.
+- Rationale: Directly validates ephemeral model (FR-002, FR-025).
+
+### Simulated Partial Failure (FR-015)
+- Decision: Induce failure before copy by mocking network (provide invalid ref) then manually create one overlay file; next run must abort due to dirty working tree.
+- Rationale: Simulates edge case without altering installer logic.
+
+### Permission / Read-Only Scenario (FR-020)
+- Decision: Create destination subdirectory with read-only attribute (Windows: attrib +R; Linux: chmod 500) affecting a file to be overwritten; assert permission diagnostic.
+- Rationale: Minimal, portable approach.
+
+## Open Items Resolved
+- All functional requirements mapped to test strategies above; no remaining NEEDS CLARIFICATION.
+
+## Alternatives Considered (Summary)
+- Custom test harness: rejected (complexity).
+- JSON structured logs: deferred until demonstrable need.
+- Caching downloads: out-of-scope per spec (FR-025 ensures overwrite each run).
+
+## Impact on Constitution
+- Parity maintained (tests run both OSes).
+- Repeatability enforced (tests isolate temp dirs, restore state via fresh git clone for each run).
+- Transparent contracts: New diagnostic patterns codified.
+
+## Risks
+- Performance flakiness due to network variability – mitigated with warn/fail thresholds.
+- Diagnostic wording drift – mitigated by specifying anchored regex patterns (explicit contract).
+
+## Next Steps
+- Phase 1: Formalize data model (conceptual entities: InstallerSession, GuardRailOutcome, DownloadAttempt) purely for test traceability.
+- Ensure plan.md includes Progress Tracking updates after Phase 0 completion.

--- a/specs/005-add-tests-for/spec.md
+++ b/specs/005-add-tests-for/spec.md
@@ -1,0 +1,177 @@
+# Feature Specification: Add Automated Tests for `install.ps1` (Bootstrap Installer Reliability & Guard Rails)
+
+**Feature Branch**: `005-add-tests-for`
+**Created**: 2025-09-16
+**Status**: Draft
+**Input**: User description: "Add tests for install.ps1 to ensure installer behavior and guard rails"
+
+## Execution Flow (main)
+```
+1. Parse user description from Input
+	→ If empty: ERROR "No feature description provided"
+2. Extract key concepts from description
+	→ Identify: actors (maintainers, contributors, CI), actions (execute installer, validate guards), data (environment vars, downloaded artifacts), constraints (idempotence, safety)
+3. For each unclear aspect:
+	→ Mark with [NEEDS CLARIFICATION: specific question]
+4. Fill User Scenarios & Testing section
+	→ If no clear user flow: ERROR "Cannot determine user scenarios"
+5. Generate Functional Requirements
+	→ Each requirement must be testable
+	→ Mark ambiguous requirements
+6. Identify Key Entities (if data involved)
+7. Run Review Checklist
+	→ If any [NEEDS CLARIFICATION]: WARN "Spec has uncertainties"
+	→ If implementation details found: ERROR "Remove tech details"
+8. Return: SUCCESS (spec ready for planning)
+```
+
+---
+
+## ⚡ Quick Guidelines
+- ✅ Focus on WHAT users need and WHY
+- ❌ Avoid HOW to implement (no tech stack, APIs, code structure)
+- 👥 Written for business stakeholders, not developers
+
+### Section Requirements
+- **Mandatory sections**: Must be completed for every feature
+- **Optional sections**: Include only when relevant to the feature
+- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### For AI Generation
+When creating this spec from a user prompt:
+1. **Mark all ambiguities**: Use [NEEDS CLARIFICATION: specific question] for any assumption you'd need to make
+2. **Don't guess**: If the prompt doesn't specify something, mark it
+3. **Think like a tester**: Every vague requirement should fail the "testable and unambiguous" checklist item
+4. **Common underspecified areas**:
+	- User types and permissions
+	- Data retention/deletion policies
+	- Performance targets and scale
+	- Error handling behaviors
+	- Integration requirements
+	- Security/compliance needs
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### Primary User Story
+As a maintainer, I need confidence that the bootstrap installer script `install.ps1` performs required environment setup safely, predictably, and idempotently so contributors can onboard or CI can prepare environments without hidden failures, destructive side effects, or silent partial configuration.
+
+### Acceptance Scenarios
+1. **Given** a clean supported Windows environment with no prior bootstrap artifacts, **When** `install.ps1` is executed with default parameters, **Then** it completes successfully and reports a clear success summary (no silent failures).
+2. **Given** the installer has already been run successfully, **When** it is executed again with the same parameters, **Then** it overwrites (replaces) previously installed overlay contents deterministically (treating prior overlay files as ephemeral) and exits successfully, guaranteeing the destination now matches the specified ref without requiring any separate update or force flag.
+3. **Given** a required prerequisite (e.g., expected external tool or version) is missing, **When** the installer runs, **Then** it fails fast with a clear diagnostic explaining what is missing and how to resolve it.
+4. **Given** an unsupported PowerShell version/environment, **When** the installer runs, **Then** it aborts with a clear guard‑rail message (no partial state changes) and non‑zero exit code.
+5. **Given** a transient download/network failure during an external acquisition step, **When** the installer runs, **Then** it reports the failure cause clearly and exits non‑zero without leaving partially applied state that would cause later confusion.
+6. **Given** the target path is not a git repository (no `.git` directory resolvable), **When** the installer is executed, **Then** it MUST abort (no file copies) with a guiding error explaining that installation requires an initialized git repo at the destination.
+7. **Given** the installer completes successfully, **When** a subsequent script or test references expected outputs (e.g., created directory structure, configuration file), **Then** those outputs are present and valid (no missing postconditions).
+8. **Given** an attempt to run the installer in a directory lacking required repository layout, **When** it is executed, **Then** it aborts with a clear context error (wrong working directory) rather than proceeding unpredictably.
+9. **Given** a user supplies an unknown parameter or flag, **When** the installer parses arguments, **Then** it rejects the input with a helpful usage summary (not silent ignore).
+10. **Given** a clean supported Ubuntu environment with PowerShell 7+ installed and a clean git working tree, **When** the installer is executed via `pwsh -File bootstrap/install.ps1`, **Then** it completes successfully with identical logical steps (semantic parity) and success summary as on Windows.
+11. **Given** the installer has already run on Ubuntu, **When** it is executed again, **Then** deterministic scoped overwrite behavior (see Scenario 2) holds identically to Windows.
+12. **Given** a simulated network failure on Ubuntu, **When** the installer retries or fails, **Then** the diagnostic format and failure semantics match Windows (differences only in platform-specific path formatting) ensuring cross-platform determinism.
+13. **Given** path handling differences between Windows (`C:\...`) and Ubuntu (`/home/...`), **When** the installer logs resolved destination and source locations, **Then** logs remain structurally comparable (step numbering, success markers) enabling unified assertion patterns.
+14. **Given** the target git repository contains any working tree modifications (staged, unstaged, or untracked files) in any path (including outside the overlay), **When** the installer is executed, **Then** it MUST abort with a guiding error instructing the user to commit, stash, remove, or otherwise clean the repository before running.
+15. **Given** the installer is run concurrently once on Windows and once on Ubuntu against distinct clean repositories, **When** both complete, **Then** each succeeds independently without cross-environment interference.
+16. **Given** the installer executes on Ubuntu, **When** it creates and later cleans up its temporary workspace under the default system temporary directory (no custom injection supported), **Then** creation succeeds under normal conditions and any failure (e.g., permission denial) produces a clear diagnostic analogous to Windows temp path failures.
+17. **Given** an already-installed overlay (regardless of whether files match the source ref), **When** the same installer command is re-run (no separate update flag), **Then** it unconditionally re-downloads the source ref and overwrites the overlay subtree to ensure exact alignment (no version comparison or skip logic).
+
+### Edge Cases
+- Re-running after a partial previous failure (where any overlay files were copied before abort) is treated as a non-clean git state; the installer MUST abort with the same working tree not clean guidance (commit, stash, or reset) and does not attempt auto self-heal.
+- Read-only file system or insufficient permissions should produce a clear permission-related failure without masking root cause.
+- Large latency on external steps should surface progress feedback (avoid appearing hung) within acceptable responsiveness.
+
+### Scope Boundaries (Non-Goals)
+- Concurrency management (multiple simultaneous executions in the same repository path) is out of scope; the installer does not provide locking or collision detection.
+- Optimizing away re-downloads for already up-to-date overlays is out of scope (every run overwrites, see FR-025).
+- Automatic recovery / cleanup of partially applied previous attempts is out of scope (treated as non-clean state per Edge Cases).
+- Offline/degraded caching behavior is out of scope; focus is on clear early fail.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+- **FR-001**: The system MUST provide automated test coverage validating successful default execution of `install.ps1` on a clean supported environment.
+- **FR-002**: The system MUST validate deterministic overwrite behavior: a second execution after success MUST replace prior overlay contents so they exactly match the source ref (ephemeral overlay model) while preserving files outside the overlay scope.
+- **FR-003**: The system MUST detect and assert correct non-zero exit with clear messaging when mandatory prerequisites are absent (guard‑rail validation).
+- **FR-004**: The system MUST enforce environment/version guard rails (e.g., minimum supported PowerShell version) via tests that confirm failure mode clarity.
+- **FR-005**: The system MUST validate that failure scenarios do not leave orphaned or partially applied critical artifacts (postcondition integrity check).
+- **FR-006**: The system MUST confirm that all expected postconditions (directories, configuration artifacts, markers) exist after successful run.
+- **FR-007**: The system MUST ensure that security / safety boundaries (restricted write locations, avoidance of privileged global modifications) are enforced and test-detectable.
+- **FR-008**: The system MUST validate argument/parameter parsing rejects unsupported inputs and surfaces a usage/help summary.
+- **FR-009**: The system MUST surface deterministic, human-readable diagnostics for each enforced guard so tests can assert on message patterns (stability requirement).
+- **FR-010**: The system MUST measure and assert that a successful default run completes within an acceptable time threshold (performance guard for regressions). Acceptable time budget <30s.
+- **FR-011**: The system MUST isolate test executions so that one failing or leaving artefacts does not impact subsequent runs (environment isolation requirement).
+- **FR-012**: The system MUST document (within contributor guidance) the tested behavioral contract for `install.ps1` so future changes can be evaluated against it.
+- **FR-013**: The system MUST provide a clear mapping from each test to a stated requirement (traceability) to ensure maintenance clarity.
+- **FR-014**: The system MUST, on any failure while downloading or extracting the repository archive (e.g., unreachable host, DNS failure, HTTP error, timeout, corrupt/invalid archive), abort before copying overlay files, emit exactly one primary diagnostic line with stable prefix `[install] download failure` containing: `ref=<ref> url=<last-attempted-url> category=<CategoryName> hint=<actionable-remediation>`, where `category` is one of {NetworkUnavailable, NotFound, CorruptArchive, Timeout, Unknown}, and then exit non-zero after cleaning its temporary workspace.
+- **FR-015**: The system MUST verify that a re-run after an intentional simulated partial failure (incomplete prior copy) is blocked identically to other non-clean states (no auto self-heal); tests assert abort with guidance to clean the repository first.
+ - **FR-016**: The system MUST execute the same core test suite on both Windows and Ubuntu using PowerShell 7+ (`pwsh`) to validate cross-platform parity of outcomes and diagnostics.
+ - **FR-017**: The system MUST ensure step numbering, success markers, and failure diagnostics remain structurally comparable across OSes (allowing only path formatting differences).
+ - **FR-018**: The system MUST assert deterministic scoped overwrite on each OS (a successful first run followed by a second run that re-applies and fully realigns overlay contents to the source ref) without relying on prior OS-specific state.
+ - **FR-019**: Each execution MUST create a unique dedicated temporary workspace under the system default temp directory, confine all transient acquisition artifacts (archive + extracted tree) to that workspace, and delete the entire workspace (best effort) before exit (success or failure). Tests MUST assert the workspace existed during execution, is removed afterward, and that no overlay files were copied to the destination prior to successful archive acquisition.
+ - **FR-020**: The system MUST detect and fail clearly on permission or filesystem constraints on Ubuntu analogous to Windows failure semantics (message clarity & non-zero exit).
+ - **FR-021**: The system MUST avoid embedding OS-specific logic in tests that would mask divergent installer behavior (tests assert platform-neutral outcomes where feasible).
+ - **FR-022**: The system MUST validate cross-platform parity by running the same core test suite on Windows and Ubuntu and requiring all parity-designated assertions to pass on both; a simple successful test pass (no dedicated parity report artifact) is sufficient—any divergence causes test failure.
+ - **FR-023**: The system MUST refuse to proceed (no copying actions) when the destination path is not a git repository (absence of `.git` or git status failure) and produce a guiding error message.
+ - **FR-024**: The system MUST refuse to proceed when the destination git repository working tree is not clean (any staged, unstaged, or untracked changes present).
+ - **FR-025**: The system MUST use a single command for initial install and all subsequent runs; every execution re-downloads the specified ref and overwrites the overlay subtree unconditionally (no version detection, no fast-skip optimization) while leaving files outside the overlay untouched.
+
+### Acquisition Failure Categories (Reference)
+Category definitions (classification only; no implementation detail implied):
+- **NetworkUnavailable**: Name resolution or network connectivity failure prevents any download attempt from succeeding.
+- **NotFound**: All candidate URLs for the specified ref return a definitive not-found response (e.g., HTTP 404) and no archive is obtained.
+- **CorruptArchive**: An archive file downloads but cannot be expanded or is structurally invalid/empty for expected contents.
+- **Timeout**: Download or extraction exceeds an expected time threshold and is aborted.
+- **Unknown**: Any other unclassified exception; still reported via the standard diagnostic format.
+
+Diagnostic Contract:
+- Single primary line only: `"[install] download failure ref=<ref> url=<url> category=<CategoryName> hint=<hint>"`.
+- `hint` provides a concise user action (e.g., "Check network connectivity and retry", "Verify ref name", "Retry later", "File appears corrupted; retry or specify a different ref").
+- No overlay files may be present in destination after failure.
+- Temporary workspace is removed (best effort) even on failure.
+
+### Key Entities
+- **Installer Session**: A conceptual execution instance with inputs (environment variables, parameters), side effects (created artifacts), and outputs (exit code, diagnostics).
+- **Guard Rail**: A policy constraint that prevents unsafe or unsupported execution (version, permissions, context validity).
+- **Postcondition Artifact**: Any file, directory, or marker whose presence/absence constitutes success criteria for a completed installer session.
+ - **Ephemeral Overlay**: The copied `overlay/` payload whose contents are always treated as replaceable during subsequent installer executions; local modifications within this subtree are not preserved and MUST be overwritten.
+
+### Temporary Workspace Behavior (Reference)
+- Log (optionally) a line identifying the temp workspace path for test discovery.
+- Workspace naming SHOULD be unique per run (e.g., random suffix) to avoid collisions.
+- No residual workspace directories from successful or failed runs are acceptable; presence of a previous run's directory constitutes a failure.
+- Overlay file copying MUST occur only after archive extraction integrity checks succeed.
+
+---
+
+## Review & Acceptance Checklist
+*GATE: Automated checks run during main() execution*
+
+### Content Quality
+- [ ] No implementation details (languages, frameworks, APIs)
+- [ ] Focused on user value and business needs
+- [ ] Written for non-technical stakeholders
+- [ ] All mandatory sections completed
+
+### Requirement Completeness
+- [ ] No [NEEDS CLARIFICATION] markers remain
+- [ ] Requirements are testable and unambiguous
+- [ ] Success criteria are measurable
+- [ ] Scope is clearly bounded
+- [ ] Dependencies and assumptions identified
+
+---
+
+## Execution Status
+*Updated by main() during processing*
+
+- [x] User description parsed
+- [x] Key concepts extracted
+- [x] Ambiguities marked
+- [x] User scenarios defined
+- [x] Requirements generated
+- [x] Entities identified
+- [ ] Review checklist passed
+
+---
+

--- a/specs/005-add-tests-for/tasks.md
+++ b/specs/005-add-tests-for/tasks.md
@@ -35,24 +35,24 @@ Guard rails & early failures first, then success/idempotence, then diagnostics c
 
 ### Download Failure Categories & Diagnostics
 - [x] T013 Create `tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1` (FR-014) – simulate network unreachable (e.g., set URL to reserved RFC1918 unreachable) expect single `[install] download failure` line with `category=NetworkUnavailable`.
-- [ ] T014 [P] Create `tests/contract/Install.DownloadFailure.NotFound.Tests.ps1` (FR-014) – bogus ref expect `category=NotFound`.
-- [ ] T015 [P] Create `tests/contract/Install.DownloadFailure.CorruptArchive.Tests.ps1` (FR-014) – serve/point to corrupt zip (may need local temp zip creation) expect `category=CorruptArchive`.
-- [ ] T016 [P] Create `tests/contract/Install.DownloadFailure.Timeout.Tests.ps1` (FR-014) – simulate timeout via extremely slow endpoint stub or injected delay harness (may start as Pending if infra not ready) expect `category=Timeout`.
-- [ ] T017 Add `tests/contract/Install.Diagnostics.Stability.Tests.ps1` (FR-009) – assert regex patterns for guard lines, success line, download failure line all anchored.^
+- [x] T014 [P] Create `tests/contract/Install.DownloadFailure.NotFound.Tests.ps1` (FR-014) – bogus ref expect `category=NotFound`.
+- [x] T015 [P] Create `tests/contract/Install.DownloadFailure.CorruptArchive.Tests.ps1` (FR-014) – serve/point to corrupt zip (may need local temp zip creation) expect `category=CorruptArchive`.
+- [x] T016 [P] Create `tests/contract/Install.DownloadFailure.Timeout.Tests.ps1` (FR-014) – simulate timeout via extremely slow endpoint stub or injected delay harness (may start as Pending if infra not ready) expect `category=Timeout`.
+- [x] T017 Add `tests/contract/Install.Diagnostics.Stability.Tests.ps1` (FR-009) – assert regex patterns for guard lines, success line, download failure line all anchored.^
 
 ### Temp Workspace & Ephemeral Behavior
-- [ ] T018 Create `tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1` (FR-019, FR-001) – capture temp path from added `[install] temp` line (test will initially force addition) assert removed post-run.
-- [ ] T019 [P] Create `tests/integration/Install.PermissionDenied.Tests.ps1` (FR-020) – create read-only target file causing copy failure expect permission diagnostic & non-zero exit.
+- [x] T018 Create `tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1` (FR-019, FR-001) – capture temp path from added `[install] temp` line (test will initially force addition) assert removed post-run.
+- [x] T019 [P] Create `tests/integration/Install.PermissionDenied.Tests.ps1` (FR-020) – create read-only target file causing copy failure expect permission diagnostic & non-zero exit.
 
 ### Performance & Isolation
-- [ ] T020 Create `tests/integration/Install.PerformanceBudget.Tests.ps1` (FR-010) – measure duration; warn >25s, fail ≥30s.
-- [ ] T021 [P] Create `tests/integration/Install.EnvironmentIsolation.Tests.ps1` (FR-011) – run two sequential installs in fresh clones ensuring no cross contamination.
+- [x] T020 Create `tests/integration/Install.PerformanceBudget.Tests.ps1` (FR-010) – measure duration; warn >25s, fail ≥30s.
+- [x] T021 [P] Create `tests/integration/Install.EnvironmentIsolation.Tests.ps1` (FR-011) – run two sequential installs in fresh clones ensuring no cross contamination.
 
 ### Cross-Platform Parity (Structure Assertions)
-- [ ] T022 Create `tests/integration/Install.Parity.Structure.Tests.ps1` (FR-016, FR-017, FR-018, FR-022) – assert consistent step numbering & messages subset independent of OS (path regex differences allowed).
+- [x] T022 Create `tests/integration/Install.Parity.Structure.Tests.ps1` (FR-016, FR-017, FR-018, FR-022) – assert consistent step numbering & messages subset independent of OS (path regex differences allowed).
 
 ### Safety / Security Boundaries
-- [ ] T023 Create `tests/contract/Install.RestrictedWrites.Tests.ps1` (FR-007) – verify no writes outside overlay path by snapshotting root before & after.
+- [x] T023 Create `tests/contract/Install.RestrictedWrites.Tests.ps1` (FR-007) – verify no writes outside overlay path by snapshotting root before & after.
 
 ## Phase 3.3: Core Adjustments (Implementation to Satisfy Failing Tests)
 (Execute only after all above tests committed & initially failing where behavior absent.)

--- a/specs/005-add-tests-for/tasks.md
+++ b/specs/005-add-tests-for/tasks.md
@@ -21,6 +21,12 @@ Sequential tasks omit [P] when they touch same file or depend on prior tasks.
 ## Phase 3.2: Tests First (TDD) – Contract & Integration (Must fail initially where behavior absent)
 Guard rails & early failures first, then success/idempotence, then diagnostics categories, then performance & parity.
 
+**Status Legend:**
+- [x] = Test created and passing
+- [f] = Test created but failing (requires implementation in Phase 3.3)
+- [s] = Test created but skipped (infrastructure not ready)
+- [ ] = Not started
+
 ### Guard Rail Contract Tests (fail-fast scenarios)
 - [x] T005 Create `tests/contract/Install.GitRepoRequired.Tests.ps1` (FR-023) – run installer in dir without `.git` expect non-zero exit & `[install] guard GitRepoRequired` (will initially fail; implementation currently warns and proceeds).
 - [x] T006 Create `tests/contract/Install.WorkingTreeNotClean.Tests.ps1` (FR-024, FR-015 edge) – simulate dirty repo (add untracked + modified file) expect abort & `[install] guard WorkingTreeNotClean`.
@@ -31,7 +37,7 @@ Guard rails & early failures first, then success/idempotence, then diagnostics c
 ### Success & Idempotence
 - [x] T010 Create `tests/integration/Install.Success.Basic.Tests.ps1` (FR-001, FR-006) – assert success summary line placeholder `[install] success ref=` (will fail until added), expected overlay files present, no extraneous writes.
 - [x] T011 [P] Create `tests/integration/Install.IdempotentOverwrite.Tests.ps1` (FR-002, FR-025) – modify file inside overlay between runs; second run restores hash.
-- [x] T012 [P] Create `tests/integration/Install.NoWritesOnFailure.Tests.ps1` (FR-005, FR-014 precondition) – force download failure (invalid ref) assert no overlay file changes.
+- [x T012 [P] Create `tests/integration/Install.NoWritesOnFailure.Tests.ps1` (FR-005, FR-014 precondition) – force download failure (invalid ref) assert no overlay file changes.
 
 ### Download Failure Categories & Diagnostics
 - [x] T013 Create `tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1` (FR-014) – simulate network unreachable (e.g., set URL to reserved RFC1918 unreachable) expect single `[install] download failure` line with `category=NetworkUnavailable`.
@@ -42,7 +48,7 @@ Guard rails & early failures first, then success/idempotence, then diagnostics c
 
 ### Temp Workspace & Ephemeral Behavior
 - [x] T018 Create `tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1` (FR-019, FR-001) – capture temp path from added `[install] temp` line (test will initially force addition) assert removed post-run.
-- [x] T019 [P] Create `tests/integration/Install.PermissionDenied.Tests.ps1` (FR-020) – create read-only target file causing copy failure expect permission diagnostic & non-zero exit.
+ - [x] T019 [P] Create `tests/integration/Install.PermissionDenied.Tests.ps1` (FR-020) – create read-only target file causing copy failure expect permission diagnostic & non-zero exit.
 
 ### Performance & Isolation
 - [x] T020 Create `tests/integration/Install.PerformanceBudget.Tests.ps1` (FR-010) – measure duration; warn >25s, fail ≥30s.
@@ -56,11 +62,11 @@ Guard rails & early failures first, then success/idempotence, then diagnostics c
 
 ## Phase 3.3: Core Adjustments (Implementation to Satisfy Failing Tests)
 (Execute only after all above tests committed & initially failing where behavior absent.)
-- [ ] T024 Add guard logic to `bootstrap/install.ps1` for git repo requirement (abort with `[install] guard GitRepoRequired` & exit code 10).
-- [ ] T025 Add working tree cleanliness check (abort with `[install] guard WorkingTreeNotClean`).
-- [ ] T026 Add unknown parameter validation (abort with usage, exit 10) – may wrap param binder or custom validation.
-- [ ] T027 Add PowerShell version guard (if <7.0 warn/fail pattern already satisfied else forced test skip logic) unify with guard prefix.
-- [ ] T028 Emit standardized success summary line `[install] success ref=<ref> overlay=<destFull> duration=<secs>`.
+- [x] T024 Add guard logic to `bootstrap/install.ps1` for git repo requirement (abort with `[install] guard GitRepoRequired` & exit code 10).
+- [x] T025 Add working tree cleanliness check (abort with `[install] guard WorkingTreeNotClean`).
+- [x] T026 Add unknown parameter validation (abort with usage, exit 10) – may wrap param binder or custom validation.
+- [x] T027 Add PowerShell version guard (if <7.0 warn/fail pattern already satisfied else forced test skip logic) unify with guard prefix.
+- [x] T028 Emit standardized success summary line `[install] success ref=<ref> overlay=<destFull> duration=<secs>`.
 - [ ] T029 Emit `[install] temp <path>` line on creation of temp workspace.
 - [ ] T030 Implement structured download failure classification & single-line diagnostic w/ categories & exit codes (20 series) – includes mapping failures to {NetworkUnavailable, NotFound, CorruptArchive, Timeout, Unknown}.
 - [ ] T031 Ensure temp workspace always removed before exit (existing finally; expand logging) & no overlay copy occurs before verified extraction.

--- a/specs/005-add-tests-for/tasks.md
+++ b/specs/005-add-tests-for/tasks.md
@@ -16,7 +16,7 @@ Sequential tasks omit [P] when they touch same file or depend on prior tasks.
 - [x] T001 Create test helper module `tests/_install/Assert-Install.psm1` with shared assertions (temp path pattern, diagnostic line matchers, hash utilities).
 - [x] T002 [P] Add test data directory `tests/_install/data/` with minimal fixture (dummy file) for hash/idempotence utilities.
 - [x] T003 Ensure Pester configuration update (if needed) in existing `scripts/run-tests.ps1` to auto-discover new `_install` helpers (skip if already globbing all tests).
-- [ ] T004 Add documentation traceability stub `specs/005-add-tests-for/traceability.md` mapping FR-001..FR-025 → test file IDs (filled as tests added).
+- [x] T004 Add documentation traceability stub `specs/005-add-tests-for/traceability.md` mapping FR-001..FR-025 → test file IDs (filled as tests added).
 
 ## Phase 3.2: Tests First (TDD) – Contract & Integration (Must fail initially where behavior absent)
 Guard rails & early failures first, then success/idempotence, then diagnostics categories, then performance & parity.

--- a/specs/005-add-tests-for/tasks.md
+++ b/specs/005-add-tests-for/tasks.md
@@ -76,8 +76,8 @@ Guard rails & early failures first, then success/idempotence, then diagnostics c
 
 ## Phase 3.5: Polish
 - [x] T039 [P] Add inline documentation comments in `bootstrap/install.ps1` for new guard sections referencing FR IDs (limited; avoid noise).
-- [ ] T040 [P] Add contributor guide snippet to `README.md` summarizing installer test contract (FR-012).
-- [ ] T041 [P] Optimize any slow test setup (cache clone for repeated parity checks without altering overwrite semantics).
+- [x] T040 [P] Add contributor guide snippet to `README.md` summarizing installer test contract (FR-012).
+- [x] T041 [P] Optimize any slow test setup (cache clone for repeated parity checks without altering overwrite semantics).
 - [ ] T042 Final consistency pass: run entire test suite locally (both categories). Capture runtime metrics.
 
 ## Dependencies

--- a/specs/005-add-tests-for/tasks.md
+++ b/specs/005-add-tests-for/tasks.md
@@ -23,10 +23,10 @@ Guard rails & early failures first, then success/idempotence, then diagnostics c
 
 ### Guard Rail Contract Tests (fail-fast scenarios)
 - [x] T005 Create `tests/contract/Install.GitRepoRequired.Tests.ps1` (FR-023) – run installer in dir without `.git` expect non-zero exit & `[install] guard GitRepoRequired` (will initially fail; implementation currently warns and proceeds).
-- [ ] T006 Create `tests/contract/Install.WorkingTreeNotClean.Tests.ps1` (FR-024, FR-015 edge) – simulate dirty repo (add untracked + modified file) expect abort & `[install] guard WorkingTreeNotClean`.
-- [ ] T007 Create `tests/contract/Install.PowerShellVersionUnsupported.Tests.ps1` (FR-004) – simulate version check via wrapper (may require implementing guard later; mark pending if version already >=7) expect guarded failure pattern.
-- [ ] T008 [P] Create `tests/contract/Install.UnknownParameter.Tests.ps1` (FR-008) – call with `-Nope123` expect rejection & usage guidance.
-- [ ] T009 [P] Create `tests/contract/Install.NonCleanAfterPartialFailure.Tests.ps1` (FR-015) – induce simulated partial copy (manually place one overlay file) then run installer expect abort & same clean working tree guidance.
+- [x] T006 Create `tests/contract/Install.WorkingTreeNotClean.Tests.ps1` (FR-024, FR-015 edge) – simulate dirty repo (add untracked + modified file) expect abort & `[install] guard WorkingTreeNotClean`.
+- [x] T007 Create `tests/contract/Install.PowerShellVersionUnsupported.Tests.ps1` (FR-004) – simulate version check via wrapper (may require implementing guard later; mark pending if version already >=7) expect guarded failure pattern.
+- [x] T008 [P] Create `tests/contract/Install.UnknownParameter.Tests.ps1` (FR-008) – call with `-Nope123` expect rejection & usage guidance.
+- [x] T009 [P] Create `tests/contract/Install.NonCleanAfterPartialFailure.Tests.ps1` (FR-015) – induce simulated partial copy (manually place one overlay file) then run installer expect abort & same clean working tree guidance.
 
 ### Success & Idempotence
 - [ ] T010 Create `tests/integration/Install.Success.Basic.Tests.ps1` (FR-001, FR-006) – assert success summary line placeholder `[install] success ref=` (will fail until added), expected overlay files present, no extraneous writes.

--- a/specs/005-add-tests-for/tasks.md
+++ b/specs/005-add-tests-for/tasks.md
@@ -22,7 +22,7 @@ Sequential tasks omit [P] when they touch same file or depend on prior tasks.
 Guard rails & early failures first, then success/idempotence, then diagnostics categories, then performance & parity.
 
 ### Guard Rail Contract Tests (fail-fast scenarios)
-- [ ] T005 Create `tests/contract/Install.GitRepoRequired.Tests.ps1` (FR-023) – run installer in dir without `.git` expect non-zero exit & `[install] guard GitRepoRequired` (will initially fail; implementation currently warns and proceeds).
+- [x] T005 Create `tests/contract/Install.GitRepoRequired.Tests.ps1` (FR-023) – run installer in dir without `.git` expect non-zero exit & `[install] guard GitRepoRequired` (will initially fail; implementation currently warns and proceeds).
 - [ ] T006 Create `tests/contract/Install.WorkingTreeNotClean.Tests.ps1` (FR-024, FR-015 edge) – simulate dirty repo (add untracked + modified file) expect abort & `[install] guard WorkingTreeNotClean`.
 - [ ] T007 Create `tests/contract/Install.PowerShellVersionUnsupported.Tests.ps1` (FR-004) – simulate version check via wrapper (may require implementing guard later; mark pending if version already >=7) expect guarded failure pattern.
 - [ ] T008 [P] Create `tests/contract/Install.UnknownParameter.Tests.ps1` (FR-008) – call with `-Nope123` expect rejection & usage guidance.

--- a/specs/005-add-tests-for/tasks.md
+++ b/specs/005-add-tests-for/tasks.md
@@ -1,0 +1,124 @@
+# Tasks: Add Automated Tests for install.ps1
+
+**Feature Directory**: D:/repos/al-build-tools/specs/005-add-tests-for
+**Input Docs Present**: plan.md, research.md, data-model.md, contracts/README.md, quickstart.md, spec.md
+**Primary Target**: `bootstrap/install.ps1`
+
+## Generation Context
+Derived from functional requirements FR-001..FR-025, conceptual entities (InstallerSession, DownloadAttempt, GuardRailOutcome), quickstart scenarios, and behavioral contracts. Focus: add black-box Pester tests (contract + integration) validating installer reliability, guard rails, diagnostics, overwrite semantics, temp workspace lifecycle, and cross-platform parity. No production code changes unless required to expose stable diagnostic lines (will be driven by initially failing tests).
+
+## Task Format
+`[ID] [P?] Description`
+[P] = Eligible to execute in parallel (different files / no ordering dependency).
+Sequential tasks omit [P] when they touch same file or depend on prior tasks.
+
+## Phase 3.1: Setup (Foundation)
+- [ ] T001 Create test helper module `tests/_install/Assert-Install.psm1` with shared assertions (temp path pattern, diagnostic line matchers, hash utilities).
+- [ ] T002 [P] Add test data directory `tests/_install/data/` with minimal fixture (dummy file) for hash/idempotence utilities.
+- [ ] T003 Ensure Pester configuration update (if needed) in existing `scripts/run-tests.ps1` to auto-discover new `_install` helpers (skip if already globbing all tests).
+- [ ] T004 Add documentation traceability stub `specs/005-add-tests-for/traceability.md` mapping FR-001..FR-025 → test file IDs (filled as tests added).
+
+## Phase 3.2: Tests First (TDD) – Contract & Integration (Must fail initially where behavior absent)
+Guard rails & early failures first, then success/idempotence, then diagnostics categories, then performance & parity.
+
+### Guard Rail Contract Tests (fail-fast scenarios)
+- [ ] T005 Create `tests/contract/Install.GitRepoRequired.Tests.ps1` (FR-023) – run installer in dir without `.git` expect non-zero exit & `[install] guard GitRepoRequired` (will initially fail; implementation currently warns and proceeds).
+- [ ] T006 Create `tests/contract/Install.WorkingTreeNotClean.Tests.ps1` (FR-024, FR-015 edge) – simulate dirty repo (add untracked + modified file) expect abort & `[install] guard WorkingTreeNotClean`.
+- [ ] T007 Create `tests/contract/Install.PowerShellVersionUnsupported.Tests.ps1` (FR-004) – simulate version check via wrapper (may require implementing guard later; mark pending if version already >=7) expect guarded failure pattern.
+- [ ] T008 [P] Create `tests/contract/Install.UnknownParameter.Tests.ps1` (FR-008) – call with `-Nope123` expect rejection & usage guidance.
+- [ ] T009 [P] Create `tests/contract/Install.NonCleanAfterPartialFailure.Tests.ps1` (FR-015) – induce simulated partial copy (manually place one overlay file) then run installer expect abort & same clean working tree guidance.
+
+### Success & Idempotence
+- [ ] T010 Create `tests/integration/Install.Success.Basic.Tests.ps1` (FR-001, FR-006) – assert success summary line placeholder `[install] success ref=` (will fail until added), expected overlay files present, no extraneous writes.
+- [ ] T011 [P] Create `tests/integration/Install.IdempotentOverwrite.Tests.ps1` (FR-002, FR-025) – modify file inside overlay between runs; second run restores hash.
+- [ ] T012 [P] Create `tests/integration/Install.NoWritesOnFailure.Tests.ps1` (FR-005, FR-014 precondition) – force download failure (invalid ref) assert no overlay file changes.
+
+### Download Failure Categories & Diagnostics
+- [ ] T013 Create `tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1` (FR-014) – simulate network unreachable (e.g., set URL to reserved RFC1918 unreachable) expect single `[install] download failure` line with `category=NetworkUnavailable`.
+- [ ] T014 [P] Create `tests/contract/Install.DownloadFailure.NotFound.Tests.ps1` (FR-014) – bogus ref expect `category=NotFound`.
+- [ ] T015 [P] Create `tests/contract/Install.DownloadFailure.CorruptArchive.Tests.ps1` (FR-014) – serve/point to corrupt zip (may need local temp zip creation) expect `category=CorruptArchive`.
+- [ ] T016 [P] Create `tests/contract/Install.DownloadFailure.Timeout.Tests.ps1` (FR-014) – simulate timeout via extremely slow endpoint stub or injected delay harness (may start as Pending if infra not ready) expect `category=Timeout`.
+- [ ] T017 Add `tests/contract/Install.Diagnostics.Stability.Tests.ps1` (FR-009) – assert regex patterns for guard lines, success line, download failure line all anchored.^
+
+### Temp Workspace & Ephemeral Behavior
+- [ ] T018 Create `tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1` (FR-019, FR-001) – capture temp path from added `[install] temp` line (test will initially force addition) assert removed post-run.
+- [ ] T019 [P] Create `tests/integration/Install.PermissionDenied.Tests.ps1` (FR-020) – create read-only target file causing copy failure expect permission diagnostic & non-zero exit.
+
+### Performance & Isolation
+- [ ] T020 Create `tests/integration/Install.PerformanceBudget.Tests.ps1` (FR-010) – measure duration; warn >25s, fail ≥30s.
+- [ ] T021 [P] Create `tests/integration/Install.EnvironmentIsolation.Tests.ps1` (FR-011) – run two sequential installs in fresh clones ensuring no cross contamination.
+
+### Cross-Platform Parity (Structure Assertions)
+- [ ] T022 Create `tests/integration/Install.Parity.Structure.Tests.ps1` (FR-016, FR-017, FR-018, FR-022) – assert consistent step numbering & messages subset independent of OS (path regex differences allowed).
+
+### Safety / Security Boundaries
+- [ ] T023 Create `tests/contract/Install.RestrictedWrites.Tests.ps1` (FR-007) – verify no writes outside overlay path by snapshotting root before & after.
+
+## Phase 3.3: Core Adjustments (Implementation to Satisfy Failing Tests)
+(Execute only after all above tests committed & initially failing where behavior absent.)
+- [ ] T024 Add guard logic to `bootstrap/install.ps1` for git repo requirement (abort with `[install] guard GitRepoRequired` & exit code 10).
+- [ ] T025 Add working tree cleanliness check (abort with `[install] guard WorkingTreeNotClean`).
+- [ ] T026 Add unknown parameter validation (abort with usage, exit 10) – may wrap param binder or custom validation.
+- [ ] T027 Add PowerShell version guard (if <7.0 warn/fail pattern already satisfied else forced test skip logic) unify with guard prefix.
+- [ ] T028 Emit standardized success summary line `[install] success ref=<ref> overlay=<destFull> duration=<secs>`.
+- [ ] T029 Emit `[install] temp <path>` line on creation of temp workspace.
+- [ ] T030 Implement structured download failure classification & single-line diagnostic w/ categories & exit codes (20 series) – includes mapping failures to {NetworkUnavailable, NotFound, CorruptArchive, Timeout, Unknown}.
+- [ ] T031 Ensure temp workspace always removed before exit (existing finally; expand logging) & no overlay copy occurs before verified extraction.
+- [ ] T032 Add permission failure detection (wrap copy with try/catch to map to exit 30 with diagnostic `[install] guard PermissionDenied`).
+- [ ] T033 Implement restricted write safety verification (guard path scope to overlay only) – fail if copy would escape dest root.
+- [ ] T034 Add elapsed time measurement & output (used by performance test) – does not enforce threshold internally (tests assert).
+- [ ] T035 Normalize step numbering / messages for parity (stable sequence names).
+
+## Phase 3.4: Integration / Refinement
+- [ ] T036 Refactor duplicated assertion helpers into `tests/_install/Assert-Install.psm1` (if drift emerged during implementation tasks).
+- [ ] T037 Update `contracts/README.md` exit code table if final exit codes differ; ensure tests updated accordingly (FR-012, FR-013 alignment).
+- [ ] T038 Update `traceability.md` with final mapping FR → Test File.
+
+## Phase 3.5: Polish
+- [ ] T039 [P] Add inline documentation comments in `bootstrap/install.ps1` for new guard sections referencing FR IDs (limited; avoid noise).
+- [ ] T040 [P] Add contributor guide snippet to `README.md` summarizing installer test contract (FR-012).
+- [ ] T041 [P] Optimize any slow test setup (cache clone for repeated parity checks without altering overwrite semantics).
+- [ ] T042 Final consistency pass: run entire test suite locally (both categories). Capture runtime metrics.
+
+## Dependencies
+- T001 before any test using shared helpers (others can scaffold pending if helper absent but recommended first).
+- Guard tests (T005-T009) precede related implementation (T024-T027, T030, T032).
+- Success/idempotence tests (T010-T012) precede success summary / classification (T028-T031, T034, T035).
+- Diagnostic category tests (T013-T017) precede download failure classification (T030).
+- Temp / permission tests (T018-T019) precede T029, T031, T032.
+- Performance & isolation (T020-T021) rely on success path (T028, T034).
+- Parity test (T022) after success + classification established (T028-T031, T034, T035).
+- Restricted write test (T023) precedes safety implementation T033.
+- Core adjustments (T024-T035) unlock integration/refinement (T036-T038) then polish (T039-T042).
+
+## Parallel Execution Examples
+```
+# Example 1: Run independent early guard tests in parallel (after T001):
+Task: T008 Install.UnknownParameter.Tests.ps1
+Task: T009 Install.NonCleanAfterPartialFailure.Tests.ps1
+
+# Example 2: Run idempotence & no-writes failure tests together:
+Task: T011 Install.IdempotentOverwrite.Tests.ps1
+Task: T012 Install.NoWritesOnFailure.Tests.ps1
+
+# Example 3: Download failure category tests (network infra permitting):
+Task: T014 NotFound
+Task: T015 CorruptArchive
+Task: T016 Timeout
+
+# Example 4: Polish parallel docs & optimization:
+Task: T039 Inline docs
+Task: T040 README snippet
+Task: T041 Optimize slow setup
+```
+
+## Validation Checklist
+- [ ] All FR-001..FR-025 mapped to at least one test or implementation task.
+- [ ] All test tasks precede implementation tasks modifying installer.
+- [ ] [P] only on tasks writing distinct files / no ordering conflicts.
+- [ ] Traceability doc stub (T004) ensures maintenance clarity.
+- [ ] Parity & performance explicitly covered (T020, T022).
+
+## Notes
+Some failure mode simulations (NetworkUnavailable, Timeout, CorruptArchive) may require controlled harness; initial tests can be marked Pending within files until harness utilities added, but tasks remain to enforce visibility.
+

--- a/specs/005-add-tests-for/tasks.md
+++ b/specs/005-add-tests-for/tasks.md
@@ -14,8 +14,8 @@ Sequential tasks omit [P] when they touch same file or depend on prior tasks.
 
 ## Phase 3.1: Setup (Foundation)
 - [x] T001 Create test helper module `tests/_install/Assert-Install.psm1` with shared assertions (temp path pattern, diagnostic line matchers, hash utilities).
-- [ ] T002 [P] Add test data directory `tests/_install/data/` with minimal fixture (dummy file) for hash/idempotence utilities.
-- [ ] T003 Ensure Pester configuration update (if needed) in existing `scripts/run-tests.ps1` to auto-discover new `_install` helpers (skip if already globbing all tests).
+- [x] T002 [P] Add test data directory `tests/_install/data/` with minimal fixture (dummy file) for hash/idempotence utilities.
+- [x] T003 Ensure Pester configuration update (if needed) in existing `scripts/run-tests.ps1` to auto-discover new `_install` helpers (skip if already globbing all tests).
 - [ ] T004 Add documentation traceability stub `specs/005-add-tests-for/traceability.md` mapping FR-001..FR-025 → test file IDs (filled as tests added).
 
 ## Phase 3.2: Tests First (TDD) – Contract & Integration (Must fail initially where behavior absent)

--- a/specs/005-add-tests-for/tasks.md
+++ b/specs/005-add-tests-for/tasks.md
@@ -13,7 +13,7 @@ Derived from functional requirements FR-001..FR-025, conceptual entities (Instal
 Sequential tasks omit [P] when they touch same file or depend on prior tasks.
 
 ## Phase 3.1: Setup (Foundation)
-- [ ] T001 Create test helper module `tests/_install/Assert-Install.psm1` with shared assertions (temp path pattern, diagnostic line matchers, hash utilities).
+- [x] T001 Create test helper module `tests/_install/Assert-Install.psm1` with shared assertions (temp path pattern, diagnostic line matchers, hash utilities).
 - [ ] T002 [P] Add test data directory `tests/_install/data/` with minimal fixture (dummy file) for hash/idempotence utilities.
 - [ ] T003 Ensure Pester configuration update (if needed) in existing `scripts/run-tests.ps1` to auto-discover new `_install` helpers (skip if already globbing all tests).
 - [ ] T004 Add documentation traceability stub `specs/005-add-tests-for/traceability.md` mapping FR-001..FR-025 → test file IDs (filled as tests added).

--- a/specs/005-add-tests-for/tasks.md
+++ b/specs/005-add-tests-for/tasks.md
@@ -21,12 +21,6 @@ Sequential tasks omit [P] when they touch same file or depend on prior tasks.
 ## Phase 3.2: Tests First (TDD) – Contract & Integration (Must fail initially where behavior absent)
 Guard rails & early failures first, then success/idempotence, then diagnostics categories, then performance & parity.
 
-**Status Legend:**
-- [x] = Test created and passing
-- [f] = Test created but failing (requires implementation in Phase 3.3)
-- [s] = Test created but skipped (infrastructure not ready)
-- [ ] = Not started
-
 ### Guard Rail Contract Tests (fail-fast scenarios)
 - [x] T005 Create `tests/contract/Install.GitRepoRequired.Tests.ps1` (FR-023) – run installer in dir without `.git` expect non-zero exit & `[install] guard GitRepoRequired` (will initially fail; implementation currently warns and proceeds).
 - [x] T006 Create `tests/contract/Install.WorkingTreeNotClean.Tests.ps1` (FR-024, FR-015 edge) – simulate dirty repo (add untracked + modified file) expect abort & `[install] guard WorkingTreeNotClean`.
@@ -37,7 +31,7 @@ Guard rails & early failures first, then success/idempotence, then diagnostics c
 ### Success & Idempotence
 - [x] T010 Create `tests/integration/Install.Success.Basic.Tests.ps1` (FR-001, FR-006) – assert success summary line placeholder `[install] success ref=` (will fail until added), expected overlay files present, no extraneous writes.
 - [x] T011 [P] Create `tests/integration/Install.IdempotentOverwrite.Tests.ps1` (FR-002, FR-025) – modify file inside overlay between runs; second run restores hash.
-- [x T012 [P] Create `tests/integration/Install.NoWritesOnFailure.Tests.ps1` (FR-005, FR-014 precondition) – force download failure (invalid ref) assert no overlay file changes.
+- [x] T012 [P] Create `tests/integration/Install.NoWritesOnFailure.Tests.ps1` (FR-005, FR-014 precondition) – force download failure (invalid ref) assert no overlay file changes.
 
 ### Download Failure Categories & Diagnostics
 - [x] T013 Create `tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1` (FR-014) – simulate network unreachable (e.g., set URL to reserved RFC1918 unreachable) expect single `[install] download failure` line with `category=NetworkUnavailable`.
@@ -48,7 +42,7 @@ Guard rails & early failures first, then success/idempotence, then diagnostics c
 
 ### Temp Workspace & Ephemeral Behavior
 - [x] T018 Create `tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1` (FR-019, FR-001) – capture temp path from added `[install] temp` line (test will initially force addition) assert removed post-run.
- - [x] T019 [P] Create `tests/integration/Install.PermissionDenied.Tests.ps1` (FR-020) – create read-only target file causing copy failure expect permission diagnostic & non-zero exit.
+- [x] T019 [P] Create `tests/integration/Install.PermissionDenied.Tests.ps1` (FR-020) – create read-only target file causing copy failure expect permission diagnostic & non-zero exit.
 
 ### Performance & Isolation
 - [x] T020 Create `tests/integration/Install.PerformanceBudget.Tests.ps1` (FR-010) – measure duration; warn >25s, fail ≥30s.
@@ -67,21 +61,21 @@ Guard rails & early failures first, then success/idempotence, then diagnostics c
 - [x] T026 Add unknown parameter validation (abort with usage, exit 10) – may wrap param binder or custom validation.
 - [x] T027 Add PowerShell version guard (if <7.0 warn/fail pattern already satisfied else forced test skip logic) unify with guard prefix.
 - [x] T028 Emit standardized success summary line `[install] success ref=<ref> overlay=<destFull> duration=<secs>`.
-- [ ] T029 Emit `[install] temp <path>` line on creation of temp workspace.
-- [ ] T030 Implement structured download failure classification & single-line diagnostic w/ categories & exit codes (20 series) – includes mapping failures to {NetworkUnavailable, NotFound, CorruptArchive, Timeout, Unknown}.
-- [ ] T031 Ensure temp workspace always removed before exit (existing finally; expand logging) & no overlay copy occurs before verified extraction.
-- [ ] T032 Add permission failure detection (wrap copy with try/catch to map to exit 30 with diagnostic `[install] guard PermissionDenied`).
-- [ ] T033 Implement restricted write safety verification (guard path scope to overlay only) – fail if copy would escape dest root.
-- [ ] T034 Add elapsed time measurement & output (used by performance test) – does not enforce threshold internally (tests assert).
-- [ ] T035 Normalize step numbering / messages for parity (stable sequence names).
+- [x] T029 Emit `[install] temp <path>` line on creation of temp workspace.
+- [x] T030 Implement structured download failure classification & single-line diagnostic w/ categories & exit codes (20 series) – includes mapping failures to {NetworkUnavailable, NotFound, CorruptArchive, Timeout, Unknown}.
+- [x] T031 Ensure temp workspace always removed before exit (existing finally; expand logging) & no overlay copy occurs before verified extraction.
+- [x] T032 Add permission failure detection (wrap copy with try/catch to map to exit 30 with diagnostic `[install] guard PermissionDenied`).
+- [x] T033 Implement restricted write safety verification (guard path scope to overlay only) – fail if copy would escape dest root.
+- [x] T034 Add elapsed time measurement & output (used by performance test) – does not enforce threshold internally (tests assert).
+- [x] T035 Normalize step numbering / messages for parity (stable sequence names).
 
 ## Phase 3.4: Integration / Refinement
-- [ ] T036 Refactor duplicated assertion helpers into `tests/_install/Assert-Install.psm1` (if drift emerged during implementation tasks).
-- [ ] T037 Update `contracts/README.md` exit code table if final exit codes differ; ensure tests updated accordingly (FR-012, FR-013 alignment).
-- [ ] T038 Update `traceability.md` with final mapping FR → Test File.
+- [x] T036 Refactor duplicated assertion helpers into `tests/_install/Assert-Install.psm1` (if drift emerged during implementation tasks).
+- [x] T037 Update `contracts/README.md` exit code table if final exit codes differ; ensure tests updated accordingly (FR-012, FR-013 alignment).
+- [x] T038 Update `traceability.md` with final mapping FR → Test File.
 
 ## Phase 3.5: Polish
-- [ ] T039 [P] Add inline documentation comments in `bootstrap/install.ps1` for new guard sections referencing FR IDs (limited; avoid noise).
+- [x] T039 [P] Add inline documentation comments in `bootstrap/install.ps1` for new guard sections referencing FR IDs (limited; avoid noise).
 - [ ] T040 [P] Add contributor guide snippet to `README.md` summarizing installer test contract (FR-012).
 - [ ] T041 [P] Optimize any slow test setup (cache clone for repeated parity checks without altering overwrite semantics).
 - [ ] T042 Final consistency pass: run entire test suite locally (both categories). Capture runtime metrics.

--- a/specs/005-add-tests-for/tasks.md
+++ b/specs/005-add-tests-for/tasks.md
@@ -29,12 +29,12 @@ Guard rails & early failures first, then success/idempotence, then diagnostics c
 - [x] T009 [P] Create `tests/contract/Install.NonCleanAfterPartialFailure.Tests.ps1` (FR-015) – induce simulated partial copy (manually place one overlay file) then run installer expect abort & same clean working tree guidance.
 
 ### Success & Idempotence
-- [ ] T010 Create `tests/integration/Install.Success.Basic.Tests.ps1` (FR-001, FR-006) – assert success summary line placeholder `[install] success ref=` (will fail until added), expected overlay files present, no extraneous writes.
-- [ ] T011 [P] Create `tests/integration/Install.IdempotentOverwrite.Tests.ps1` (FR-002, FR-025) – modify file inside overlay between runs; second run restores hash.
-- [ ] T012 [P] Create `tests/integration/Install.NoWritesOnFailure.Tests.ps1` (FR-005, FR-014 precondition) – force download failure (invalid ref) assert no overlay file changes.
+- [x] T010 Create `tests/integration/Install.Success.Basic.Tests.ps1` (FR-001, FR-006) – assert success summary line placeholder `[install] success ref=` (will fail until added), expected overlay files present, no extraneous writes.
+- [x] T011 [P] Create `tests/integration/Install.IdempotentOverwrite.Tests.ps1` (FR-002, FR-025) – modify file inside overlay between runs; second run restores hash.
+- [x] T012 [P] Create `tests/integration/Install.NoWritesOnFailure.Tests.ps1` (FR-005, FR-014 precondition) – force download failure (invalid ref) assert no overlay file changes.
 
 ### Download Failure Categories & Diagnostics
-- [ ] T013 Create `tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1` (FR-014) – simulate network unreachable (e.g., set URL to reserved RFC1918 unreachable) expect single `[install] download failure` line with `category=NetworkUnavailable`.
+- [x] T013 Create `tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1` (FR-014) – simulate network unreachable (e.g., set URL to reserved RFC1918 unreachable) expect single `[install] download failure` line with `category=NetworkUnavailable`.
 - [ ] T014 [P] Create `tests/contract/Install.DownloadFailure.NotFound.Tests.ps1` (FR-014) – bogus ref expect `category=NotFound`.
 - [ ] T015 [P] Create `tests/contract/Install.DownloadFailure.CorruptArchive.Tests.ps1` (FR-014) – serve/point to corrupt zip (may need local temp zip creation) expect `category=CorruptArchive`.
 - [ ] T016 [P] Create `tests/contract/Install.DownloadFailure.Timeout.Tests.ps1` (FR-014) – simulate timeout via extremely slow endpoint stub or injected delay harness (may start as Pending if infra not ready) expect `category=Timeout`.

--- a/specs/005-add-tests-for/traceability.md
+++ b/specs/005-add-tests-for/traceability.md
@@ -4,30 +4,30 @@ This living stub aligns functional requirements (FR-001..FR-025) with the test f
 
 | FR ID | Planned/Pending Test Coverage | Notes |
 |-------|--------------------------------|-------|
-| FR-001 | T010 – `tests/integration/Install.Success.Basic.Tests.ps1`<br>T018 – `tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1` | Validates happy path completion and temp workspace lifecycle. |
-| FR-002 | T011 – `tests/integration/Install.IdempotentOverwrite.Tests.ps1` | Confirms deterministic overwrite behavior on rerun. |
+| FR-001 | T010 - `tests/integration/Install.Success.Basic.Tests.ps1`<br>T018 - `tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1` | Validates happy path completion and temp workspace lifecycle. |
+| FR-002 | T011 - `tests/integration/Install.IdempotentOverwrite.Tests.ps1` | Confirms deterministic overwrite behavior on rerun. |
 | FR-003 | _(pending)_ | Identify prerequisite guard scenario (e.g., missing required tool) and add dedicated contract test. |
-| FR-004 | T007 – `tests/contract/Install.PowerShellVersionUnsupported.Tests.ps1` | Ensures version guard blocks unsupported PowerShell. |
-| FR-005 | T012 – `tests/integration/Install.NoWritesOnFailure.Tests.ps1` | Asserts no overlay writes occur when acquisition fails. |
-| FR-006 | T010 – `tests/integration/Install.Success.Basic.Tests.ps1` | Confirms expected postconditions after success. |
-| FR-007 | T023 – `tests/contract/Install.RestrictedWrites.Tests.ps1` | Guards against filesystem writes outside overlay scope. |
-| FR-008 | T008 – `tests/contract/Install.UnknownParameter.Tests.ps1` | Verifies unsupported arguments are rejected with guidance. |
-| FR-009 | T017 – `tests/contract/Install.Diagnostics.Stability.Tests.ps1` | Locks diagnostic line format for guards/success/failure. |
-| FR-010 | T020 – `tests/integration/Install.PerformanceBudget.Tests.ps1` | Tracks runtime against <30s performance target. |
-| FR-011 | T021 – `tests/integration/Install.EnvironmentIsolation.Tests.ps1` | Ensures sequential runs remain isolated. |
-| FR-012 | T040 – `README` contributor guide snippet | Documentation requirement captured via repo docs update. |
-| FR-013 | T004/T038 – `specs/005-add-tests-for/traceability.md` | This matrix provides ongoing requirement-to-test mapping. |
-| FR-014 | T012 – `tests/integration/Install.NoWritesOnFailure.Tests.ps1`<br>T013 – `tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1`<br>T014 – `tests/contract/Install.DownloadFailure.NotFound.Tests.ps1`<br>T015 – `tests/contract/Install.DownloadFailure.CorruptArchive.Tests.ps1`<br>T016 – `tests/contract/Install.DownloadFailure.Timeout.Tests.ps1` | Covers download failure classification and side-effect guards. |
-| FR-015 | T009 – `tests/contract/Install.NonCleanAfterPartialFailure.Tests.ps1` | Validates rerun blocked when repo dirty after partial copy. |
-| FR-016 | T022 – `tests/integration/Install.Parity.Structure.Tests.ps1` | Shared structure assertions across OSes. |
-| FR-017 | T022 – `tests/integration/Install.Parity.Structure.Tests.ps1` | Ensures diagnostics and steps align cross-platform. |
-| FR-018 | T011 – `tests/integration/Install.IdempotentOverwrite.Tests.ps1`<br>T022 – `tests/integration/Install.Parity.Structure.Tests.ps1` | Confirms overwrite parity on each OS. |
-| FR-019 | T018 – `tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1` | Observes temp workspace creation/removal. |
-| FR-020 | T019 – `tests/integration/Install.PermissionDenied.Tests.ps1` | Simulates permission-denied copy failure. |
-| FR-021 | T001 – `tests/_install/Assert-Install.psm1` helpers<br>T022 – `tests/integration/Install.Parity.Structure.Tests.ps1` | Shared helpers keep assertions platform-neutral; parity test enforces no OS-specific drift. |
-| FR-022 | T022 – `tests/integration/Install.Parity.Structure.Tests.ps1` | Single suite expected to pass on Windows & Ubuntu. |
-| FR-023 | T005 – `tests/contract/Install.GitRepoRequired.Tests.ps1` | Guard for missing git repository. |
-| FR-024 | T006 – `tests/contract/Install.WorkingTreeNotClean.Tests.ps1` | Guard for dirty git state. |
-| FR-025 | T011 – `tests/integration/Install.IdempotentOverwrite.Tests.ps1` | One-command install/update idempotence enforcement. |
+| FR-004 | T007 - `tests/contract/Install.PowerShellVersionUnsupported.Tests.ps1` | Ensures version guard blocks unsupported PowerShell. |
+| FR-005 | T012 - `tests/integration/Install.NoWritesOnFailure.Tests.ps1` | Asserts no overlay writes occur when acquisition fails. |
+| FR-006 | T010 - `tests/integration/Install.Success.Basic.Tests.ps1` | Confirms expected postconditions after success. |
+| FR-007 | T023 - `tests/contract/Install.RestrictedWrites.Tests.ps1` | Guards against filesystem writes outside overlay scope. |
+| FR-008 | T008 - `tests/contract/Install.UnknownParameter.Tests.ps1` | Verifies unsupported arguments are rejected with guidance. |
+| FR-009 | T017 - `tests/contract/Install.Diagnostics.Stability.Tests.ps1` | Locks diagnostic line format for guards/success/failure. |
+| FR-010 | T020 - `tests/integration/Install.PerformanceBudget.Tests.ps1` | Tracks runtime against <30s performance target. |
+| FR-011 | T021 - `tests/integration/Install.EnvironmentIsolation.Tests.ps1` | Ensures sequential runs remain isolated. |
+| FR-012 | T040 - `README` contributor guide snippet | Documentation requirement captured via repo docs update. |
+| FR-013 | T004/T038 - `specs/005-add-tests-for/traceability.md` | This matrix provides ongoing requirement-to-test mapping. |
+| FR-014 | T012 - `tests/integration/Install.NoWritesOnFailure.Tests.ps1`<br>T013 - `tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1`<br>T014 - `tests/contract/Install.DownloadFailure.NotFound.Tests.ps1`<br>T015 - `tests/contract/Install.DownloadFailure.CorruptArchive.Tests.ps1`<br>T016 - `tests/contract/Install.DownloadFailure.Timeout.Tests.ps1` | Covers download failure classification and side-effect guards. |
+| FR-015 | T009 - `tests/contract/Install.NonCleanAfterPartialFailure.Tests.ps1` | Validates rerun blocked when repo dirty after partial copy. |
+| FR-016 | T022 - `tests/integration/Install.Parity.Structure.Tests.ps1` | Shared structure assertions across OSes. |
+| FR-017 | T022 - `tests/integration/Install.Parity.Structure.Tests.ps1` | Ensures diagnostics and steps align cross-platform. |
+| FR-018 | T011 - `tests/integration/Install.IdempotentOverwrite.Tests.ps1`<br>T022 - `tests/integration/Install.Parity.Structure.Tests.ps1` | Confirms overwrite parity on each OS. |
+| FR-019 | T018 - `tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1` | Observes temp workspace creation/removal. |
+| FR-020 | T019 - `tests/integration/Install.PermissionDenied.Tests.ps1` | Simulates permission-denied copy failure. |
+| FR-021 | T001 - `tests/_install/Assert-Install.psm1` helpers<br>T022 - `tests/integration/Install.Parity.Structure.Tests.ps1` | Shared helpers keep assertions platform-neutral; parity test enforces no OS-specific drift. |
+| FR-022 | T022 - `tests/integration/Install.Parity.Structure.Tests.ps1` | Single suite expected to pass on Windows & Ubuntu. |
+| FR-023 | T005 - `tests/contract/Install.GitRepoRequired.Tests.ps1` | Guard for missing git repository. |
+| FR-024 | T006 - `tests/contract/Install.WorkingTreeNotClean.Tests.ps1` | Guard for dirty git state. |
+| FR-025 | T011 - `tests/integration/Install.IdempotentOverwrite.Tests.ps1` | One-command install/update idempotence enforcement. |
 
-_Last updated: 2025-09-16._
+_Last updated: 2025-09-16 - T006-T009 contract tests added._

--- a/specs/005-add-tests-for/traceability.md
+++ b/specs/005-add-tests-for/traceability.md
@@ -1,33 +1,33 @@
 # Traceability: install.ps1 Test Coverage
 
-This living stub aligns functional requirements (FR-001..FR-025) with the test files that will verify them. Update the "Planned/Pending Test Coverage" column as each test lands or file names change.
+This matrix captures the definitive mapping between functional requirements FR-001..FR-025 and the automated coverage (tests or documentation) that enforces each behavior.
 
-| FR ID | Planned/Pending Test Coverage | Notes |
-|-------|--------------------------------|-------|
-| FR-001 | T010 - `tests/integration/Install.Success.Basic.Tests.ps1`<br>T018 - `tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1` | Validates happy path completion and temp workspace lifecycle. |
-| FR-002 | T011 - `tests/integration/Install.IdempotentOverwrite.Tests.ps1` | Confirms deterministic overwrite behavior on rerun. |
-| FR-003 | _(pending)_ | Identify prerequisite guard scenario (e.g., missing required tool) and add dedicated contract test. |
-| FR-004 | T007 - `tests/contract/Install.PowerShellVersionUnsupported.Tests.ps1` | Ensures version guard blocks unsupported PowerShell. |
-| FR-005 | T012 - `tests/integration/Install.NoWritesOnFailure.Tests.ps1` | Asserts no overlay writes occur when acquisition fails. |
-| FR-006 | T010 - `tests/integration/Install.Success.Basic.Tests.ps1` | Confirms expected postconditions after success. |
-| FR-007 | T023 - `tests/contract/Install.RestrictedWrites.Tests.ps1` | Guards against filesystem writes outside overlay scope. |
-| FR-008 | T008 - `tests/contract/Install.UnknownParameter.Tests.ps1` | Verifies unsupported arguments are rejected with guidance. |
-| FR-009 | T017 - `tests/contract/Install.Diagnostics.Stability.Tests.ps1` | Locks diagnostic line format for guards/success/failure. |
-| FR-010 | T020 - `tests/integration/Install.PerformanceBudget.Tests.ps1` | Tracks runtime against <30s performance target. |
-| FR-011 | T021 - `tests/integration/Install.EnvironmentIsolation.Tests.ps1` | Ensures sequential runs remain isolated. |
-| FR-012 | T040 - `README` contributor guide snippet | Documentation requirement captured via repo docs update. |
-| FR-013 | T004/T038 - `specs/005-add-tests-for/traceability.md` | This matrix provides ongoing requirement-to-test mapping. |
-| FR-014 | T012 - `tests/integration/Install.NoWritesOnFailure.Tests.ps1`<br>T013 - `tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1`<br>T014 - `tests/contract/Install.DownloadFailure.NotFound.Tests.ps1`<br>T015 - `tests/contract/Install.DownloadFailure.CorruptArchive.Tests.ps1`<br>T016 - `tests/contract/Install.DownloadFailure.Timeout.Tests.ps1` | Covers download failure classification and side-effect guards. |
-| FR-015 | T009 - `tests/contract/Install.NonCleanAfterPartialFailure.Tests.ps1` | Validates rerun blocked when repo dirty after partial copy. |
-| FR-016 | T022 - `tests/integration/Install.Parity.Structure.Tests.ps1` | Shared structure assertions across OSes. |
-| FR-017 | T022 - `tests/integration/Install.Parity.Structure.Tests.ps1` | Ensures diagnostics and steps align cross-platform. |
-| FR-018 | T011 - `tests/integration/Install.IdempotentOverwrite.Tests.ps1`<br>T022 - `tests/integration/Install.Parity.Structure.Tests.ps1` | Confirms overwrite parity on each OS. |
-| FR-019 | T018 - `tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1` | Observes temp workspace creation/removal. |
-| FR-020 | T019 - `tests/integration/Install.PermissionDenied.Tests.ps1` | Simulates permission-denied copy failure. |
-| FR-021 | T001 - `tests/_install/Assert-Install.psm1` helpers<br>T022 - `tests/integration/Install.Parity.Structure.Tests.ps1` | Shared helpers keep assertions platform-neutral; parity test enforces no OS-specific drift. |
-| FR-022 | T022 - `tests/integration/Install.Parity.Structure.Tests.ps1` | Single suite expected to pass on Windows & Ubuntu. |
-| FR-023 | T005 - `tests/contract/Install.GitRepoRequired.Tests.ps1`<br>T024 - Implementation complete | Guard for missing git repository. Implementation verified working. |
-| FR-024 | T006 - `tests/contract/Install.WorkingTreeNotClean.Tests.ps1` | Guard for dirty git state. |
-| FR-025 | T011 - `tests/integration/Install.IdempotentOverwrite.Tests.ps1` | One-command install/update idempotence enforcement. |
+| FR ID | Implemented Coverage | Notes |
+|-------|-----------------------|-------|
+| FR-001 | `tests/integration/Install.Success.Basic.Tests.ps1`<br>`tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1` | Validates happy-path completion including temp workspace observability. |
+| FR-002 | `tests/integration/Install.IdempotentOverwrite.Tests.ps1` | Confirms deterministic overwrite behavior on repeat installs. |
+| FR-003 | `tests/contract/Install.GitRepoRequired.Tests.ps1`<br>`tests/contract/Install.PowerShellVersionUnsupported.Tests.ps1` | Guards fail fast when mandatory prerequisites (git metadata, supported pwsh) are absent. |
+| FR-004 | `tests/contract/Install.PowerShellVersionUnsupported.Tests.ps1` | Forces failure with `[install] guard PowerShellVersionUnsupported` on unsupported versions. |
+| FR-005 | `tests/integration/Install.NoWritesOnFailure.Tests.ps1` | Asserts destination is untouched when acquisition fails. |
+| FR-006 | `tests/integration/Install.Success.Basic.Tests.ps1` | Checks required overlay artifacts and success diagnostics after completion. |
+| FR-007 | `tests/contract/Install.RestrictedWrites.Tests.ps1` | Ensures copy never escapes overlay scope. |
+| FR-008 | `tests/contract/Install.UnknownParameter.Tests.ps1` | Rejects unsupported parameters with usage guidance. |
+| FR-009 | `tests/contract/Install.Diagnostics.Stability.Tests.ps1` | Locks guard, success, and failure diagnostic formats. |
+| FR-010 | `tests/integration/Install.PerformanceBudget.Tests.ps1` | Enforces sub-30s performance budget via parsed duration. |
+| FR-011 | `tests/integration/Install.EnvironmentIsolation.Tests.ps1` | Runs sequential installs in isolated repos to prevent cross-run contamination. |
+| FR-012 | _(pending: update `README.md` contributor guidance via T040)_ | Documentation gate remains to be authored. |
+| FR-013 | `specs/005-add-tests-for/traceability.md` | This document provides the maintained FR ↔ coverage mapping. |
+| FR-014 | `tests/integration/Install.NoWritesOnFailure.Tests.ps1`<br>`tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1`<br>`tests/contract/Install.DownloadFailure.NotFound.Tests.ps1`<br>`tests/contract/Install.DownloadFailure.CorruptArchive.Tests.ps1`<br>`tests/contract/Install.DownloadFailure.Timeout.Tests.ps1` | Verifies single-line diagnostics, categorized failures, and no side-effects on acquisition errors. |
+| FR-015 | `tests/contract/Install.NonCleanAfterPartialFailure.Tests.ps1` | Treats residue from partial copy as dirty working tree. |
+| FR-016 | `tests/integration/Install.Parity.Structure.Tests.ps1` | Asserts consistent step sequencing/labels across platforms. |
+| FR-017 | `tests/integration/Install.Parity.Structure.Tests.ps1` | Checks diagnostics remain structurally comparable regardless of OS paths. |
+| FR-018 | `tests/integration/Install.IdempotentOverwrite.Tests.ps1`<br>`tests/integration/Install.EnvironmentIsolation.Tests.ps1` | Ensures deterministic overwrites on each OS and no stale state. |
+| FR-019 | `tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1`<br>`tests/integration/Install.EnvironmentIsolation.Tests.ps1` | Validates temp workspace creation/cleanup and uniqueness per run. |
+| FR-020 | `tests/integration/Install.PermissionDenied.Tests.ps1` | Surfaces `[install] guard PermissionDenied` when filesystem blocks writes. |
+| FR-021 | `tests/_install/Assert-Install.psm1`<br>`tests/integration/Install.Parity.Structure.Tests.ps1` | Helpers enforce path-agnostic assertions; parity suite ensures no OS-specific drift. |
+| FR-022 | `tests/integration/Install.Parity.Structure.Tests.ps1`<br>`tests/integration/Install.EnvironmentIsolation.Tests.ps1` | Requires parity-focused suites to pass on Windows and Ubuntu. |
+| FR-023 | `tests/contract/Install.GitRepoRequired.Tests.ps1` | Fails with `[install] guard GitRepoRequired` outside a git repo. |
+| FR-024 | `tests/contract/Install.WorkingTreeNotClean.Tests.ps1` | Blocks execution when working tree is dirty. |
+| FR-025 | `tests/integration/Install.IdempotentOverwrite.Tests.ps1` | Confirms single-command install/update flow realigns overlay exactly. |
 
-_Last updated: 2025-09-17 - T024 implementation verified complete (git repo guard logic already implemented and tested)._
+_Last updated: 2025-09-17 — T038 complete; FR-012 remains pending until README guidance ships._

--- a/specs/005-add-tests-for/traceability.md
+++ b/specs/005-add-tests-for/traceability.md
@@ -1,0 +1,33 @@
+# Traceability: install.ps1 Test Coverage
+
+This living stub aligns functional requirements (FR-001..FR-025) with the test files that will verify them. Update the "Planned/Pending Test Coverage" column as each test lands or file names change.
+
+| FR ID | Planned/Pending Test Coverage | Notes |
+|-------|--------------------------------|-------|
+| FR-001 | T010 – `tests/integration/Install.Success.Basic.Tests.ps1`<br>T018 – `tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1` | Validates happy path completion and temp workspace lifecycle. |
+| FR-002 | T011 – `tests/integration/Install.IdempotentOverwrite.Tests.ps1` | Confirms deterministic overwrite behavior on rerun. |
+| FR-003 | _(pending)_ | Identify prerequisite guard scenario (e.g., missing required tool) and add dedicated contract test. |
+| FR-004 | T007 – `tests/contract/Install.PowerShellVersionUnsupported.Tests.ps1` | Ensures version guard blocks unsupported PowerShell. |
+| FR-005 | T012 – `tests/integration/Install.NoWritesOnFailure.Tests.ps1` | Asserts no overlay writes occur when acquisition fails. |
+| FR-006 | T010 – `tests/integration/Install.Success.Basic.Tests.ps1` | Confirms expected postconditions after success. |
+| FR-007 | T023 – `tests/contract/Install.RestrictedWrites.Tests.ps1` | Guards against filesystem writes outside overlay scope. |
+| FR-008 | T008 – `tests/contract/Install.UnknownParameter.Tests.ps1` | Verifies unsupported arguments are rejected with guidance. |
+| FR-009 | T017 – `tests/contract/Install.Diagnostics.Stability.Tests.ps1` | Locks diagnostic line format for guards/success/failure. |
+| FR-010 | T020 – `tests/integration/Install.PerformanceBudget.Tests.ps1` | Tracks runtime against <30s performance target. |
+| FR-011 | T021 – `tests/integration/Install.EnvironmentIsolation.Tests.ps1` | Ensures sequential runs remain isolated. |
+| FR-012 | T040 – `README` contributor guide snippet | Documentation requirement captured via repo docs update. |
+| FR-013 | T004/T038 – `specs/005-add-tests-for/traceability.md` | This matrix provides ongoing requirement-to-test mapping. |
+| FR-014 | T012 – `tests/integration/Install.NoWritesOnFailure.Tests.ps1`<br>T013 – `tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1`<br>T014 – `tests/contract/Install.DownloadFailure.NotFound.Tests.ps1`<br>T015 – `tests/contract/Install.DownloadFailure.CorruptArchive.Tests.ps1`<br>T016 – `tests/contract/Install.DownloadFailure.Timeout.Tests.ps1` | Covers download failure classification and side-effect guards. |
+| FR-015 | T009 – `tests/contract/Install.NonCleanAfterPartialFailure.Tests.ps1` | Validates rerun blocked when repo dirty after partial copy. |
+| FR-016 | T022 – `tests/integration/Install.Parity.Structure.Tests.ps1` | Shared structure assertions across OSes. |
+| FR-017 | T022 – `tests/integration/Install.Parity.Structure.Tests.ps1` | Ensures diagnostics and steps align cross-platform. |
+| FR-018 | T011 – `tests/integration/Install.IdempotentOverwrite.Tests.ps1`<br>T022 – `tests/integration/Install.Parity.Structure.Tests.ps1` | Confirms overwrite parity on each OS. |
+| FR-019 | T018 – `tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1` | Observes temp workspace creation/removal. |
+| FR-020 | T019 – `tests/integration/Install.PermissionDenied.Tests.ps1` | Simulates permission-denied copy failure. |
+| FR-021 | T001 – `tests/_install/Assert-Install.psm1` helpers<br>T022 – `tests/integration/Install.Parity.Structure.Tests.ps1` | Shared helpers keep assertions platform-neutral; parity test enforces no OS-specific drift. |
+| FR-022 | T022 – `tests/integration/Install.Parity.Structure.Tests.ps1` | Single suite expected to pass on Windows & Ubuntu. |
+| FR-023 | T005 – `tests/contract/Install.GitRepoRequired.Tests.ps1` | Guard for missing git repository. |
+| FR-024 | T006 – `tests/contract/Install.WorkingTreeNotClean.Tests.ps1` | Guard for dirty git state. |
+| FR-025 | T011 – `tests/integration/Install.IdempotentOverwrite.Tests.ps1` | One-command install/update idempotence enforcement. |
+
+_Last updated: 2025-09-16._

--- a/specs/005-add-tests-for/traceability.md
+++ b/specs/005-add-tests-for/traceability.md
@@ -26,8 +26,8 @@ This living stub aligns functional requirements (FR-001..FR-025) with the test f
 | FR-020 | T019 - `tests/integration/Install.PermissionDenied.Tests.ps1` | Simulates permission-denied copy failure. |
 | FR-021 | T001 - `tests/_install/Assert-Install.psm1` helpers<br>T022 - `tests/integration/Install.Parity.Structure.Tests.ps1` | Shared helpers keep assertions platform-neutral; parity test enforces no OS-specific drift. |
 | FR-022 | T022 - `tests/integration/Install.Parity.Structure.Tests.ps1` | Single suite expected to pass on Windows & Ubuntu. |
-| FR-023 | T005 - `tests/contract/Install.GitRepoRequired.Tests.ps1` | Guard for missing git repository. |
+| FR-023 | T005 - `tests/contract/Install.GitRepoRequired.Tests.ps1`<br>T024 - Implementation complete | Guard for missing git repository. Implementation verified working. |
 | FR-024 | T006 - `tests/contract/Install.WorkingTreeNotClean.Tests.ps1` | Guard for dirty git state. |
 | FR-025 | T011 - `tests/integration/Install.IdempotentOverwrite.Tests.ps1` | One-command install/update idempotence enforcement. |
 
-_Last updated: 2025-09-16 - T006-T009 contract tests added._
+_Last updated: 2025-09-17 - T024 implementation verified complete (git repo guard logic already implemented and tested)._

--- a/specs/005-add-tests-for/traceability.md
+++ b/specs/005-add-tests-for/traceability.md
@@ -15,7 +15,7 @@ This matrix captures the definitive mapping between functional requirements FR-0
 | FR-009 | `tests/contract/Install.Diagnostics.Stability.Tests.ps1` | Locks guard, success, and failure diagnostic formats. |
 | FR-010 | `tests/integration/Install.PerformanceBudget.Tests.ps1` | Enforces sub-30s performance budget via parsed duration. |
 | FR-011 | `tests/integration/Install.EnvironmentIsolation.Tests.ps1` | Runs sequential installs in isolated repos to prevent cross-run contamination. |
-| FR-012 | _(pending: update `README.md` contributor guidance via T040)_ | Documentation gate remains to be authored. |
+| FR-012 | `README.md` (Installer Test Contract)<br>`tests/contract/Install.*.Tests.ps1`<br>`tests/integration/Install.*.Tests.ps1` | Contributor guidance summarizes enforced behaviors and points to suites; update when coverage shifts. |
 | FR-013 | `specs/005-add-tests-for/traceability.md` | This document provides the maintained FR ↔ coverage mapping. |
 | FR-014 | `tests/integration/Install.NoWritesOnFailure.Tests.ps1`<br>`tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1`<br>`tests/contract/Install.DownloadFailure.NotFound.Tests.ps1`<br>`tests/contract/Install.DownloadFailure.CorruptArchive.Tests.ps1`<br>`tests/contract/Install.DownloadFailure.Timeout.Tests.ps1` | Verifies single-line diagnostics, categorized failures, and no side-effects on acquisition errors. |
 | FR-015 | `tests/contract/Install.NonCleanAfterPartialFailure.Tests.ps1` | Treats residue from partial copy as dirty working tree. |
@@ -30,4 +30,4 @@ This matrix captures the definitive mapping between functional requirements FR-0
 | FR-024 | `tests/contract/Install.WorkingTreeNotClean.Tests.ps1` | Blocks execution when working tree is dirty. |
 | FR-025 | `tests/integration/Install.IdempotentOverwrite.Tests.ps1` | Confirms single-command install/update flow realigns overlay exactly. |
 
-_Last updated: 2025-09-17 — T038 complete; FR-012 remains pending until README guidance ships._
+_Last updated: 2025-09-17 — T040 complete; README Installer Test Contract documents FR-012._

--- a/tests/_install/Assert-Install.psm1
+++ b/tests/_install/Assert-Install.psm1
@@ -263,7 +263,8 @@ function Get-InstallDirectorySnapshot {
         }
     }
 
-    return $snapshot
+    # Always return an array, even if empty or single item
+    return ,$snapshot
 }
 
 function Compare-InstallSnapshots {

--- a/tests/_install/Assert-Install.psm1
+++ b/tests/_install/Assert-Install.psm1
@@ -1,0 +1,362 @@
+
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+$script:InstallTempLinePattern = '^\[install\]\s+temp\s+(?<Pairs>.+)$'
+$script:InstallSuccessLinePattern = '^\[install\]\s+success\s+(?<Pairs>.+)$'
+$script:InstallGuardLinePattern = '^\[install\]\s+guard\s+(?<Guard>[A-Za-z0-9]+)(?<Pairs>(?:\s+[A-Za-z0-9_-]+=.*)*)$'
+$script:InstallDownloadFailurePattern = '^\[install\]\s+download\s+failure\s+(?<Pairs>.+)$'
+$script:InstallDownloadCategories = @('NetworkUnavailable','NotFound','CorruptArchive','Timeout','Unknown')
+
+function ConvertFrom-InstallQuotedValue {
+    param(
+        [string] $Value
+    )
+
+    if ($null -eq $Value) { return $null }
+    $trim = $Value.Trim()
+    if ($trim.Length -ge 2) {
+        if ($trim.StartsWith('"') -and $trim.EndsWith('"')) {
+            return $trim.Substring(1, $trim.Length - 2).Replace('""', '"')
+        }
+        if ($trim.StartsWith("'") -and $trim.EndsWith("'")) {
+            return $trim.Substring(1, $trim.Length - 2).Replace("''", "'")
+        }
+    }
+    return $trim
+}
+
+function Get-InstallKeyValueMap {
+    param(
+        [string] $Text
+    )
+
+    $map = [ordered]@{}
+    if ([string]::IsNullOrWhiteSpace($Text)) { return $map }
+
+    # Parse key=value segments while allowing spaces in values by stopping at the next key token.
+    $pattern = '(?<Key>[A-Za-z0-9_-]+)=(?<Value>.*?)(?=\s+[A-Za-z0-9_-]+=|$)'
+    foreach ($match in [regex]::Matches($Text, $pattern)) {
+        $key = $match.Groups['Key'].Value
+        $value = ConvertFrom-InstallQuotedValue -Value ($match.Groups['Value'].Value.Trim())
+        $map[$key] = $value
+    }
+
+    return $map
+}
+
+function Assert-InstallTempPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [string] $Because = 'Expected installer temp workspace to reside under the system temporary directory.'
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "Temp workspace path is empty. $Because"
+    }
+
+    if (-not [IO.Path]::IsPathRooted($Path)) {
+        throw "Temp workspace path '$Path' must be absolute. $Because"
+    }
+
+    try {
+        $full = [IO.Path]::GetFullPath($Path)
+    } catch {
+        throw "Temp workspace path '$Path' is not a valid file system path. $Because`n$($_.Exception.Message)"
+    }
+
+    $tempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+    if (-not $full.StartsWith($tempRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Temp workspace path '$full' is not located under '$tempRoot'. $Because"
+    }
+
+    $leaf = Split-Path -Path $full -Leaf
+    if ($leaf -notmatch '^[A-Za-z0-9][A-Za-z0-9_\.-]{2,}$') {
+        throw "Temp workspace directory name '$leaf' does not match expected random pattern. $Because"
+    }
+
+    return $full
+}
+
+function Assert-InstallTempLine {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string] $Line
+    )
+
+    $match = [regex]::Match($Line, $script:InstallTempLinePattern)
+    if (-not $match.Success) {
+        throw "Line '$Line' does not match expected '[install] temp' diagnostic pattern."
+    }
+
+    $pairs = Get-InstallKeyValueMap -Text $match.Groups['Pairs'].Value
+    if (-not $pairs.Contains('workspace')) {
+        throw "Temp diagnostic line '$Line' must include 'workspace=' token."
+    }
+
+    $normalized = Assert-InstallTempPath -Path $pairs['workspace']
+    return [pscustomobject]@{
+        Workspace = $normalized
+        Pairs = $pairs
+        RawLine = $Line
+    }
+}
+
+function Assert-InstallSuccessLine {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string] $Line,
+        [string] $ExpectedRef,
+        [string] $ExpectedOverlay,
+        [double] $MaxDurationSeconds
+    )
+
+    $match = [regex]::Match($Line, $script:InstallSuccessLinePattern)
+    if (-not $match.Success) {
+        throw "Line '$Line' does not match expected '[install] success' diagnostic pattern."
+    }
+
+    $pairs = Get-InstallKeyValueMap -Text $match.Groups['Pairs'].Value
+    foreach ($required in @('ref','overlay','duration')) {
+        if (-not $pairs.Contains($required)) {
+            throw "Success diagnostic line '$Line' is missing '$required='."
+        }
+    }
+
+    try {
+        $duration = [double]::Parse($pairs['duration'], [System.Globalization.CultureInfo]::InvariantCulture)
+    } catch {
+        throw "Duration value '$($pairs['duration'])' from line '$Line' is not numeric."
+    }
+
+    if ($duration -lt 0) {
+        throw "Duration value '$duration' from line '$Line' cannot be negative."
+    }
+
+    if ($PSBoundParameters.ContainsKey('ExpectedRef') -and $pairs['ref'] -ne $ExpectedRef) {
+        throw "Expected ref '$ExpectedRef' but found '$($pairs['ref'])' in line '$Line'."
+    }
+
+    if ($PSBoundParameters.ContainsKey('ExpectedOverlay') -and $pairs['overlay'] -ne $ExpectedOverlay) {
+        throw "Expected overlay '$ExpectedOverlay' but found '$($pairs['overlay'])' in line '$Line'."
+    }
+
+    if ($PSBoundParameters.ContainsKey('MaxDurationSeconds') -and $duration -gt $MaxDurationSeconds) {
+        throw "Duration '$duration' from line '$Line' exceeds allowed max $MaxDurationSeconds seconds."
+    }
+
+    return [pscustomobject]@{
+        Ref = $pairs['ref']
+        Overlay = $pairs['overlay']
+        DurationSeconds = $duration
+        Pairs = $pairs
+        RawLine = $Line
+    }
+}
+
+function Assert-InstallGuardLine {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string] $Line,
+        [string] $ExpectedGuard
+    )
+
+    $match = [regex]::Match($Line, $script:InstallGuardLinePattern)
+    if (-not $match.Success) {
+        throw "Line '$Line' does not match expected '[install] guard <Name>' diagnostic pattern."
+    }
+
+    $guard = $match.Groups['Guard'].Value
+    if ($PSBoundParameters.ContainsKey('ExpectedGuard') -and $guard -ne $ExpectedGuard) {
+        throw "Expected guard '$ExpectedGuard' but found '$guard' in line '$Line'."
+    }
+
+    $pairs = Get-InstallKeyValueMap -Text $match.Groups['Pairs'].Value
+    return [pscustomobject]@{
+        Guard = $guard
+        Pairs = $pairs
+        RawLine = $Line
+    }
+}
+
+function Assert-InstallDownloadFailureLine {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string] $Line,
+        [string] $ExpectedRef,
+        [string] $ExpectedUrl,
+        [string] $ExpectedCategory
+    )
+
+    $match = [regex]::Match($Line, $script:InstallDownloadFailurePattern)
+    if (-not $match.Success) {
+        throw "Line '$Line' does not match expected '[install] download failure' diagnostic pattern."
+    }
+
+    $pairs = Get-InstallKeyValueMap -Text $match.Groups['Pairs'].Value
+    foreach ($required in @('ref','url','category','hint')) {
+        if (-not $pairs.Contains($required)) {
+            throw "Download failure diagnostic line '$Line' is missing '$required='."
+        }
+    }
+
+    if ($script:InstallDownloadCategories -notcontains $pairs['category']) {
+        $allowed = $script:InstallDownloadCategories -join ', '
+        throw "Unexpected download failure category '$($pairs['category'])'. Allowed: $allowed."
+    }
+
+    try {
+        [void][Uri]$pairs['url']
+    } catch {
+        throw "URL '$($pairs['url'])' from line '$Line' is not a valid URI."
+    }
+
+    if ($PSBoundParameters.ContainsKey('ExpectedRef') -and $pairs['ref'] -ne $ExpectedRef) {
+        throw "Expected ref '$ExpectedRef' but found '$($pairs['ref'])' in line '$Line'."
+    }
+
+    if ($PSBoundParameters.ContainsKey('ExpectedUrl') -and $pairs['url'] -ne $ExpectedUrl) {
+        throw "Expected url '$ExpectedUrl' but found '$($pairs['url'])' in line '$Line'."
+    }
+
+    if ($PSBoundParameters.ContainsKey('ExpectedCategory') -and $pairs['category'] -ne $ExpectedCategory) {
+        throw "Expected category '$ExpectedCategory' but found '$($pairs['category'])' in line '$Line'."
+    }
+
+    return [pscustomobject]@{
+        Ref = $pairs['ref']
+        Url = $pairs['url']
+        Category = $pairs['category']
+        Hint = $pairs['hint']
+        Pairs = $pairs
+        RawLine = $Line
+    }
+}
+
+function Get-InstallDirectorySnapshot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [string] $BasePath
+    )
+
+    $resolved = Resolve-Path -LiteralPath $Path -ErrorAction Stop
+    if ($PSBoundParameters.ContainsKey('BasePath')) {
+        $baseResolved = Resolve-Path -LiteralPath $BasePath -ErrorAction Stop
+    } else {
+        $baseResolved = $resolved
+    }
+
+    $rootPath = [IO.Path]::GetFullPath($baseResolved.Path)
+    $files = Get-ChildItem -LiteralPath $resolved.Path -Recurse -File | Sort-Object -Property FullName
+
+    $snapshot = @()
+    foreach ($file in $files) {
+        $hash = Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256
+        $relative = [IO.Path]::GetRelativePath($rootPath, $file.FullName)
+        $normalized = $relative -replace '\', '/'
+        $snapshot += [pscustomobject]@{
+            Path = $normalized
+            Hash = $hash.Hash.ToLowerInvariant()
+            Length = $file.Length
+        }
+    }
+
+    return $snapshot
+}
+
+function Compare-InstallSnapshots {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [System.Collections.IEnumerable] $Expected,
+        [Parameter(Mandatory)] [System.Collections.IEnumerable] $Actual
+    )
+
+    $expectedMap = @{}
+    foreach ($item in $Expected) {
+        if ($null -eq $item) { continue }
+        if (-not $item.PSObject.Properties.Match('Path')) { continue }
+        $expectedMap[$item.Path] = $item
+    }
+
+    $actualMap = @{}
+    foreach ($item in $Actual) {
+        if ($null -eq $item) { continue }
+        if (-not $item.PSObject.Properties.Match('Path')) { continue }
+        $actualMap[$item.Path] = $item
+    }
+
+    $missing = @()
+    foreach ($path in $expectedMap.Keys) {
+        if (-not $actualMap.ContainsKey($path)) { $missing += $path }
+    }
+
+    $extra = @()
+    foreach ($path in $actualMap.Keys) {
+        if (-not $expectedMap.ContainsKey($path)) { $extra += $path }
+    }
+
+    $hashMismatches = @()
+    foreach ($path in $expectedMap.Keys) {
+        if ($actualMap.ContainsKey($path)) {
+            $expectedItem = $expectedMap[$path]
+            $actualItem = $actualMap[$path]
+            if ($expectedItem.Hash -ne $actualItem.Hash) {
+                $hashMismatches += [pscustomobject]@{
+                    Path = $path
+                    ExpectedHash = $expectedItem.Hash
+                    ActualHash = $actualItem.Hash
+                    ExpectedLength = $expectedItem.Length
+                    ActualLength = $actualItem.Length
+                }
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        Missing = $missing
+        Extra = $extra
+        HashMismatches = $hashMismatches
+    }
+}
+
+function Assert-InstallSnapshotsEqual {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [System.Collections.IEnumerable] $Expected,
+        [Parameter(Mandatory)] [System.Collections.IEnumerable] $Actual,
+        [string] $Because = 'Directory fingerprints differ.'
+    )
+
+    $diff = Compare-InstallSnapshots -Expected $Expected -Actual $Actual
+
+    $missingCount = ($diff.Missing | Measure-Object).Count
+    $extraCount = ($diff.Extra | Measure-Object).Count
+    $mismatchCount = ($diff.HashMismatches | Measure-Object).Count
+
+    if ($missingCount -eq 0 -and $extraCount -eq 0 -and $mismatchCount -eq 0) {
+        return $true
+    }
+
+    $parts = @()
+    if ($missingCount -gt 0) { $parts += "missing: $($diff.Missing -join ', ')" }
+    if ($extraCount -gt 0) { $parts += "extra: $($diff.Extra -join ', ')" }
+    if ($mismatchCount -gt 0) {
+        $summaries = $diff.HashMismatches | ForEach-Object { '{0} (expected={1} actual={2})' -f $_.Path, $_.ExpectedHash, $_.ActualHash }
+        $parts += "hash mismatches: $($summaries -join '; ')"
+    }
+
+    $joined = $parts -join '; '
+    throw "$Because Differences -> $joined"
+}
+
+Export-ModuleMember -Function `
+    Assert-InstallTempPath, `
+    Assert-InstallTempLine, `
+    Assert-InstallSuccessLine, `
+    Assert-InstallGuardLine, `
+    Assert-InstallDownloadFailureLine, `
+    Get-InstallDirectorySnapshot, `
+    Compare-InstallSnapshots, `
+    Assert-InstallSnapshotsEqual

--- a/tests/_install/Assert-Install.psm1
+++ b/tests/_install/Assert-Install.psm1
@@ -255,7 +255,7 @@ function Get-InstallDirectorySnapshot {
     foreach ($file in $files) {
         $hash = Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256
         $relative = [IO.Path]::GetRelativePath($rootPath, $file.FullName)
-        $normalized = $relative -replace '\', '/'
+        $normalized = $relative -replace '\\', '/'
         $snapshot += [pscustomobject]@{
             Path = $normalized
             Hash = $hash.Hash.ToLowerInvariant()

--- a/tests/_install/InstallArchiveServer.psm1
+++ b/tests/_install/InstallArchiveServer.psm1
@@ -1,0 +1,167 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+function New-InstallArchive {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    param(
+        [Parameter(Mandatory)] [string] $RepoRoot,
+        [Parameter(Mandatory)] [string] $Workspace,
+        [string] $Ref = 'main'
+    )
+
+    $resolvedRepo = (Resolve-Path -LiteralPath $RepoRoot -ErrorAction Stop).Path
+    if (-not (Test-Path -LiteralPath $Workspace)) {
+        New-Item -ItemType Directory -Path $Workspace | Out-Null
+    }
+    $resolvedWorkspace = (Resolve-Path -LiteralPath $Workspace -ErrorAction Stop).Path
+
+    if (-not $PSCmdlet.ShouldProcess("workspace '$resolvedWorkspace'", 'Initialize install archive staging area')) {
+        return
+    }
+
+    $packageRoot = Join-Path $resolvedWorkspace 'archive'
+    if (Test-Path -LiteralPath $packageRoot) {
+        Remove-Item -LiteralPath $packageRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    New-Item -ItemType Directory -Path $packageRoot | Out-Null
+
+    $topName = "al-build-tools-$Ref"
+    $topRoot = Join-Path $packageRoot $topName
+    New-Item -ItemType Directory -Path $topRoot | Out-Null
+
+    $overlaySource = Join-Path $resolvedRepo 'overlay'
+    Copy-Item -LiteralPath $overlaySource -Destination $topRoot -Recurse -Force
+
+    $zipPath = Join-Path $resolvedWorkspace 'overlay-package.zip'
+    if (Test-Path -LiteralPath $zipPath) {
+        Remove-Item -LiteralPath $zipPath -Force -ErrorAction SilentlyContinue
+    }
+    Compress-Archive -Path (Join-Path $packageRoot '*') -DestinationPath $zipPath -Force
+
+    return [pscustomobject]@{
+        ZipPath  = (Resolve-Path -LiteralPath $zipPath).Path
+        RootName = $topName
+    }
+}
+
+function Start-InstallArchiveServer {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(Mandatory)] [string] $ZipPath,
+        [string] $BasePath = 'albt',
+        [int] $StatusCode = 200,
+        [int] $Port
+    )
+
+    $resolvedZip = (Resolve-Path -LiteralPath $ZipPath -ErrorAction Stop).Path
+
+    if (-not (Get-Command Start-ThreadJob -ErrorAction SilentlyContinue)) {
+        Import-Module ThreadJob -ErrorAction Stop
+    }
+
+    if (-not $PSBoundParameters.ContainsKey('Port') -or $Port -le 0) {
+        $Port = Get-Random -Minimum 20000 -Maximum 45000
+    }
+
+    $prefix = "http://127.0.0.1:$Port/"
+    if (-not $PSCmdlet.ShouldProcess($prefix, 'Start install archive server')) {
+        return
+    }
+
+    $listener = [System.Net.HttpListener]::new()
+    $listener.Prefixes.Add($prefix)
+    $listener.Start()
+
+    $archiveBytes = [System.IO.File]::ReadAllBytes($resolvedZip)
+
+    $job = Start-ThreadJob -ArgumentList $listener, $archiveBytes, $StatusCode -ScriptBlock {
+        param($listener, $bytes, $statusCode)
+        while ($true) {
+            try {
+                $context = $listener.GetContext()
+            } catch {
+                Write-Verbose "[InstallArchiveServer] Listener stopped: $($_.Exception.Message)"
+                break
+            }
+
+            try {
+                if ($statusCode -eq 200) {
+                    $context.Response.StatusCode = 200
+                    $context.Response.ContentType = 'application/zip'
+                    $context.Response.ContentLength64 = $bytes.LongLength
+                    $context.Response.OutputStream.Write($bytes, 0, $bytes.Length)
+                } else {
+                    $context.Response.StatusCode = $statusCode
+                }
+            } catch {
+                Write-Verbose "[InstallArchiveServer] Failed to write response: $($_.Exception.Message)"
+                try { $context.Response.StatusCode = 500 } catch { Write-Verbose "[InstallArchiveServer] Failed to set error status: $($_.Exception.Message)" }
+            } finally {
+                try { $context.Response.OutputStream.Flush() } catch { Write-Verbose "[InstallArchiveServer] Flush failed: $($_.Exception.Message)" }
+                try { $context.Response.OutputStream.Close() } catch { Write-Verbose "[InstallArchiveServer] Close failed: $($_.Exception.Message)" }
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        Listener   = $listener
+        Job        = $job
+        BaseUrl    = "http://127.0.0.1:$Port/$BasePath"
+        Prefix     = $prefix
+        StatusCode = $StatusCode
+    }
+}
+
+function Stop-InstallArchiveServer {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    param(
+        [Parameter(Mandatory)] [psobject] $Server
+    )
+
+    if ($null -eq $Server) { return }
+
+    if (-not $PSCmdlet.ShouldProcess('install archive server resources', 'Stop install archive server')) {
+        return
+    }
+
+    if ($Server.Listener) {
+        try {
+            $Server.Listener.Stop()
+        } catch {
+            Write-Verbose "[InstallArchiveServer] Listener stop failed: $($_.Exception.Message)"
+        }
+
+        try {
+            $Server.Listener.Close()
+        } catch {
+            Write-Verbose "[InstallArchiveServer] Listener close failed: $($_.Exception.Message)"
+        }
+    }
+
+    if ($Server.Job) {
+        try {
+            Wait-Job -Job $Server.Job -Timeout 2 | Out-Null
+        } catch {
+            Write-Verbose "[InstallArchiveServer] Wait-Job failed: $($_.Exception.Message)"
+        }
+
+        if ($Server.Job.State -notin @('Completed', 'Failed', 'Stopped')) {
+            try {
+                Stop-Job -Job $Server.Job -Force -ErrorAction SilentlyContinue
+            } catch {
+                Write-Verbose "[InstallArchiveServer] Stop-Job failed: $($_.Exception.Message)"
+            }
+        }
+
+        try {
+            Receive-Job -Job $Server.Job -Wait -AutoRemoveJob | Out-Null
+        } catch {
+            Write-Verbose "[InstallArchiveServer] Receive-Job failed: $($_.Exception.Message)"
+        }
+    }
+}
+
+Export-ModuleMember -Function `
+    New-InstallArchive, `
+    Start-InstallArchiveServer, `
+    Stop-InstallArchiveServer

--- a/tests/_install/Invoke-Install.psm1
+++ b/tests/_install/Invoke-Install.psm1
@@ -1,0 +1,111 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+function New-InstallTestWorkspace {
+    [CmdletBinding()]
+    param(
+        [string] $Prefix = 'albt-install-'
+    )
+
+    $root = Join-Path ([IO.Path]::GetTempPath()) ($Prefix + [Guid]::NewGuid().ToString('N'))
+    if (-not (Test-Path -LiteralPath $root)) {
+        New-Item -ItemType Directory -Path $root | Out-Null
+    }
+
+    return (Resolve-Path -LiteralPath $root).Path
+}
+
+function Initialize-InstallTestRepo {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string] $Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        New-Item -ItemType Directory -Path $Path | Out-Null
+    }
+
+    & git -C $Path init | Out-Null
+    & git -C $Path config user.email 'albt-tests@example.com' | Out-Null
+    & git -C $Path config user.name 'ALBT Tests' | Out-Null
+    & git -C $Path config commit.gpgsign false | Out-Null
+
+    $tracked = Join-Path $Path 'README.md'
+    Set-Content -Path $tracked -Value 'bootstrap install test repository' -NoNewline
+    & git -C $Path add README.md | Out-Null
+    & git -C $Path commit -m 'Initial commit for install guard tests' | Out-Null
+
+    return (Resolve-Path -LiteralPath $Path).Path
+}
+
+function Invoke-InstallScript {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string] $RepoRoot,
+        [Parameter(Mandatory)] [string] $Dest,
+        [string] $Url = 'https://127.0.0.1:65535/al-build-tools',
+        [string] $Ref = 'main',
+        [string] $Source = 'overlay',
+        [hashtable] $Environment = @{},
+        [string[]] $AdditionalArguments = @()
+    )
+
+    $scriptPath = Join-Path $RepoRoot 'bootstrap' 'install.ps1'
+
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = 'pwsh'
+    $psi.WorkingDirectory = $RepoRoot
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.UseShellExecute = $false
+
+    $null = $psi.ArgumentList.Add('-NoLogo')
+    $null = $psi.ArgumentList.Add('-NoProfile')
+    $null = $psi.ArgumentList.Add('-File')
+    $null = $psi.ArgumentList.Add($scriptPath)
+    $null = $psi.ArgumentList.Add('-Dest')
+    $null = $psi.ArgumentList.Add($Dest)
+    $null = $psi.ArgumentList.Add('-Url')
+    $null = $psi.ArgumentList.Add($Url)
+    $null = $psi.ArgumentList.Add('-Ref')
+    $null = $psi.ArgumentList.Add($Ref)
+    $null = $psi.ArgumentList.Add('-Source')
+    $null = $psi.ArgumentList.Add($Source)
+
+    foreach ($arg in $AdditionalArguments) {
+        if ([string]::IsNullOrWhiteSpace($arg)) { continue }
+        $null = $psi.ArgumentList.Add($arg)
+    }
+
+    foreach ($key in $Environment.Keys) {
+        $psi.Environment[$key] = [string]$Environment[$key]
+    }
+
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $proc.WaitForExit()
+
+    return [pscustomobject]@{
+        ExitCode = $proc.ExitCode
+        StdOut   = $proc.StandardOutput.ReadToEnd()
+        StdErr   = $proc.StandardError.ReadToEnd()
+    }
+}
+
+function Get-InstallOutputLines {
+    [CmdletBinding()]
+    param(
+        [string] $StdOut,
+        [string] $StdErr
+    )
+
+    $lines = @()
+    if ($StdOut) { $lines += $StdOut -split "(`r`n|`n)" }
+    if ($StdErr) { $lines += $StdErr -split "(`r`n|`n)" }
+    return $lines | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+}
+
+Export-ModuleMember -Function `
+    New-InstallTestWorkspace, `
+    Initialize-InstallTestRepo, `
+    Invoke-InstallScript, `
+    Get-InstallOutputLines

--- a/tests/_install/data/overlay-placeholder.txt
+++ b/tests/_install/data/overlay-placeholder.txt
@@ -1,0 +1,2 @@
+Install overlay fixture payload.
+Used by installer tests to validate hashing and idempotence logic.

--- a/tests/contract/Baseline.Tests.ps1
+++ b/tests/contract/Baseline.Tests.ps1
@@ -1,32 +1,9 @@
 #requires -Version 7.0
 
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+
 Describe 'Baseline contracts for current behavior' {
     BeforeAll {
-        function Invoke-ChildPwsh {
-            param(
-                [Parameter(Mandatory)] [string] $ScriptPath,
-                [string] $Arguments,
-                [string] $WorkingDirectory,
-                [hashtable] $Env
-            )
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = "pwsh"
-            $psi.Arguments = "-NoLogo -NoProfile -File `"$ScriptPath`" $Arguments"
-            if ($WorkingDirectory) { $psi.WorkingDirectory = $WorkingDirectory }
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            if ($Env) {
-                foreach ($k in $Env.Keys) { $psi.Environment[$k] = [string]$Env[$k] }
-            }
-            $proc = [System.Diagnostics.Process]::Start($psi)
-            $proc.WaitForExit()
-            $exit = $proc.ExitCode
-            $outStr = $proc.StandardOutput.ReadToEnd()
-            $errStr = $proc.StandardError.ReadToEnd()
-            return [pscustomobject]@{ ExitCode = $exit; StdOut = $outStr; StdErr = $errStr }
-        }
-
         $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
         $OverlayMake = Join-Path $RepoRoot 'overlay/scripts/make'
 

--- a/tests/contract/Guard.Tests.ps1
+++ b/tests/contract/Guard.Tests.ps1
@@ -1,29 +1,9 @@
 #requires -Version 7.0
 
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+
 Describe 'Guard enforcement for make-only entrypoints' {
     BeforeAll {
-        function Invoke-ChildPwsh {
-            param(
-                [Parameter(Mandatory)] [string] $File,
-                [string] $Args,
-                [hashtable] $Env
-            )
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = "pwsh"
-            $psi.Arguments = "-NoLogo -NoProfile -File `"$File`" $Args"
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            if ($Env) { foreach ($k in $Env.Keys) { $psi.Environment[$k] = [string]$Env[$k] } }
-            $p = [System.Diagnostics.Process]::Start($psi)
-            $p.WaitForExit()
-            [pscustomobject]@{
-                ExitCode = $p.ExitCode
-                StdOut   = $p.StandardOutput.ReadToEnd()
-                StdErr   = $p.StandardError.ReadToEnd()
-            }
-        }
-
         $RepoRoot    = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
         $ScriptsRoot = Join-Path $RepoRoot 'overlay/scripts/make'
         $TempRoot    = Join-Path ([IO.Path]::GetTempPath()) ("albt-guard-" + [Guid]::NewGuid().ToString('N'))
@@ -36,25 +16,25 @@ Describe 'Guard enforcement for make-only entrypoints' {
 
     Context 'direct invocation without ALBT_VIA_MAKE' {
         It 'exits 2 with guidance for clean.ps1' {
-            $res = Invoke-ChildPwsh -File (Join-Path $ScriptsRoot 'clean.ps1') -Args "`"$TempRoot`""
+            $res = Invoke-ChildPwsh -ScriptPath (Join-Path $ScriptsRoot 'clean.ps1') -Arguments "`"$TempRoot`""
             $res.ExitCode | Should -Be 2
             $res.StdOut   | Should -Match 'Run via make'
         }
 
         It 'exits 2 with guidance for show-config.ps1' {
-            $res = Invoke-ChildPwsh -File (Join-Path $ScriptsRoot 'show-config.ps1') -Args "`"$TempRoot`""
+            $res = Invoke-ChildPwsh -ScriptPath (Join-Path $ScriptsRoot 'show-config.ps1') -Arguments "`"$TempRoot`""
             $res.ExitCode | Should -Be 2
             $res.StdOut   | Should -Match 'Run via make'
         }
 
         It 'exits 2 with guidance for show-analyzers.ps1' {
-            $res = Invoke-ChildPwsh -File (Join-Path $ScriptsRoot 'show-analyzers.ps1') -Args "`"$TempRoot`""
+            $res = Invoke-ChildPwsh -ScriptPath (Join-Path $ScriptsRoot 'show-analyzers.ps1') -Arguments "`"$TempRoot`""
             $res.ExitCode | Should -Be 2
             $res.StdOut   | Should -Match 'Run via make'
         }
 
         It 'exits 2 with guidance for build.ps1' {
-            $res = Invoke-ChildPwsh -File (Join-Path $ScriptsRoot 'build.ps1') -Args "`"$TempRoot`""
+            $res = Invoke-ChildPwsh -ScriptPath (Join-Path $ScriptsRoot 'build.ps1') -Arguments "`"$TempRoot`""
             $res.ExitCode | Should -Be 2
             $res.StdOut   | Should -Match 'Run via make'
         }
@@ -62,14 +42,14 @@ Describe 'Guard enforcement for make-only entrypoints' {
 
     Context 'invocation with ALBT_VIA_MAKE set' {
         It 'allows clean.ps1 to proceed (exit 0)' {
-            $res = Invoke-ChildPwsh -File (Join-Path $ScriptsRoot 'clean.ps1') -Args "`"$TempRoot`"" -Env @{ ALBT_VIA_MAKE = '1' }
+            $res = Invoke-ChildPwsh -ScriptPath (Join-Path $ScriptsRoot 'clean.ps1') -Arguments "`"$TempRoot`"" -Env @{ ALBT_VIA_MAKE = '1' }
             $res.ExitCode | Should -Be 0
         }
     }
 
     Context 'help-like args still guard' {
         It 'exits 2 when passing "/?" to clean.ps1' {
-            $res = Invoke-ChildPwsh -File (Join-Path $ScriptsRoot 'clean.ps1') -Args ' /?'
+            $res = Invoke-ChildPwsh -ScriptPath (Join-Path $ScriptsRoot 'clean.ps1') -Arguments ' /?'
             $res.ExitCode | Should -Be 2
             $res.StdOut   | Should -Match 'Run via make'
         }

--- a/tests/contract/Install.Diagnostics.Stability.Tests.ps1
+++ b/tests/contract/Install.Diagnostics.Stability.Tests.ps1
@@ -1,0 +1,110 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'InstallArchiveServer.psm1') -Force
+
+Describe 'Installer diagnostics stability' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-diag-'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'emits anchored guard diagnostics' {
+        $caseRoot = Join-Path $script:WorkspaceRoot ("guard-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $caseRoot | Out-Null
+
+        $dest = Join-Path $caseRoot 'dest'
+        New-Item -ItemType Directory -Path $dest | Out-Null
+
+        try {
+            $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest
+
+            $result.ExitCode | Should -Not -Be 0
+
+            $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+            $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }
+            $guardLine | Should -Not -BeNullOrEmpty
+
+            $parsed = Assert-InstallGuardLine -Line $guardLine[0]
+            $parsed.RawLine.StartsWith('[install] guard') | Should -BeTrue
+        }
+        finally {
+            if (Test-Path -LiteralPath $caseRoot) {
+                Remove-Item -LiteralPath $caseRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'emits anchored success diagnostics' {
+        $caseRoot = Join-Path $script:WorkspaceRoot ("success-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $caseRoot | Out-Null
+
+        $destRoot = Join-Path $caseRoot 'repo'
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        $archiveWorkspace = Join-Path $caseRoot 'pkg'
+        $archive = New-InstallArchive -RepoRoot $script:RepoRoot -Workspace $archiveWorkspace
+
+        $server = $null
+        try {
+            $server = Start-InstallArchiveServer -ZipPath $archive.ZipPath -BasePath ('albt-' + [Guid]::NewGuid().ToString('N'))
+            $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref 'main'
+
+            $result.ExitCode | Should -Be 0
+
+            $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+            $successLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }
+            $successLine | Should -Not -BeNullOrEmpty
+
+            $parsed = Assert-InstallSuccessLine -Line $successLine[0] -ExpectedRef 'main' -ExpectedOverlay 'overlay' -MaxDurationSeconds 300
+            $parsed.RawLine.StartsWith('[install] success') | Should -BeTrue
+        }
+        finally {
+            if ($server) { Stop-InstallArchiveServer -Server $server }
+            if (Test-Path -LiteralPath $caseRoot) {
+                Remove-Item -LiteralPath $caseRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'emits anchored download failure diagnostics' {
+        $caseRoot = Join-Path $script:WorkspaceRoot ("download-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $caseRoot | Out-Null
+
+        $destRoot = Join-Path $caseRoot 'repo'
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        $archiveWorkspace = Join-Path $caseRoot 'pkg'
+        $archive = New-InstallArchive -RepoRoot $script:RepoRoot -Workspace $archiveWorkspace
+
+        $server = $null
+        try {
+            $server = Start-InstallArchiveServer -ZipPath $archive.ZipPath -BasePath ('albt-' + [Guid]::NewGuid().ToString('N')) -StatusCode 404
+            $missingRef = 'missing-' + [Guid]::NewGuid().ToString('N')
+            $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref $missingRef
+
+            $result.ExitCode | Should -Not -Be 0
+
+            $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+            $failureLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+download\s+failure\s+' }
+            $failureLine | Should -Not -BeNullOrEmpty
+
+            $parsed = Assert-InstallDownloadFailureLine -Line $failureLine[-1] -ExpectedRef $missingRef
+            $parsed.RawLine.StartsWith('[install] download failure') | Should -BeTrue
+        }
+        finally {
+            if ($server) { Stop-InstallArchiveServer -Server $server }
+            if (Test-Path -LiteralPath $caseRoot) {
+                Remove-Item -LiteralPath $caseRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/contract/Install.Diagnostics.Stability.Tests.ps1
+++ b/tests/contract/Install.Diagnostics.Stability.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'Installer diagnostics stability' {
         try {
             $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest
 
-            $result.ExitCode | Should -Not -Be 0
+            $result.ExitCode | Should -Be 10
 
             $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
             $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }
@@ -91,7 +91,7 @@ Describe 'Installer diagnostics stability' {
             $missingRef = 'missing-' + [Guid]::NewGuid().ToString('N')
             $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref $missingRef
 
-            $result.ExitCode | Should -Not -Be 0
+            $result.ExitCode | Should -Be 20
 
             $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
             $failureLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+download\s+failure\s+' }

--- a/tests/contract/Install.Diagnostics.Stability.Tests.ps1
+++ b/tests/contract/Install.Diagnostics.Stability.Tests.ps1
@@ -33,7 +33,7 @@ Describe 'Installer diagnostics stability' {
             $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }
             $guardLine | Should -Not -BeNullOrEmpty
 
-            $parsed = Assert-InstallGuardLine -Line $guardLine[0]
+            $parsed = Assert-InstallGuardLine -Line $guardLine
             $parsed.RawLine.StartsWith('[install] guard') | Should -BeTrue
         }
         finally {
@@ -64,7 +64,7 @@ Describe 'Installer diagnostics stability' {
             $successLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }
             $successLine | Should -Not -BeNullOrEmpty
 
-            $parsed = Assert-InstallSuccessLine -Line $successLine[0] -ExpectedRef 'main' -ExpectedOverlay 'overlay' -MaxDurationSeconds 300
+            $parsed = Assert-InstallSuccessLine -Line $successLine -ExpectedRef 'main' -ExpectedOverlay 'overlay' -MaxDurationSeconds 300
             $parsed.RawLine.StartsWith('[install] success') | Should -BeTrue
         }
         finally {
@@ -97,7 +97,7 @@ Describe 'Installer diagnostics stability' {
             $failureLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+download\s+failure\s+' }
             $failureLine | Should -Not -BeNullOrEmpty
 
-            $parsed = Assert-InstallDownloadFailureLine -Line $failureLine[-1] -ExpectedRef $missingRef
+            $parsed = Assert-InstallDownloadFailureLine -Line $failureLine -ExpectedRef $missingRef
             $parsed.RawLine.StartsWith('[install] download failure') | Should -BeTrue
         }
         finally {

--- a/tests/contract/Install.DownloadFailure.CorruptArchive.Tests.ps1
+++ b/tests/contract/Install.DownloadFailure.CorruptArchive.Tests.ps1
@@ -42,7 +42,7 @@ Describe 'Installer download failure categorization: corrupt archive' {
             $failureLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+download\s+failure\s+' }
             $failureLine | Should -Not -BeNullOrEmpty
 
-            $failure = Assert-InstallDownloadFailureLine -Line $failureLine[-1] -ExpectedRef 'main' -ExpectedCategory 'CorruptArchive'
+            $failure = Assert-InstallDownloadFailureLine -Line $failureLine -ExpectedRef 'main' -ExpectedCategory 'CorruptArchive'
             $failure.Category | Should -Be 'CorruptArchive'
         }
         finally {

--- a/tests/contract/Install.DownloadFailure.CorruptArchive.Tests.ps1
+++ b/tests/contract/Install.DownloadFailure.CorruptArchive.Tests.ps1
@@ -1,0 +1,55 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'InstallArchiveServer.psm1') -Force
+
+Describe 'Installer download failure categorization: corrupt archive' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-corrupt-'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'emits CorruptArchive category when downloaded bytes are not a valid zip' {
+        $caseRoot = Join-Path $script:WorkspaceRoot ("case-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $caseRoot | Out-Null
+
+        $destRoot = Join-Path $caseRoot 'repo'
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        $archiveWorkspace = Join-Path $caseRoot 'pkg'
+        $archive = New-InstallArchive -RepoRoot $script:RepoRoot -Workspace $archiveWorkspace
+
+        $corruptZip = $archive.ZipPath
+        Set-Content -LiteralPath $corruptZip -Value 'not-a-zip-archive' -NoNewline
+
+        $server = $null
+        try {
+            $server = Start-InstallArchiveServer -ZipPath $corruptZip -BasePath ('albt-' + [Guid]::NewGuid().ToString('N'))
+
+            $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref 'main'
+
+            $result.ExitCode | Should -Not -Be 0
+
+            $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+            $failureLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+download\s+failure\s+' }
+            $failureLine | Should -Not -BeNullOrEmpty
+
+            $failure = Assert-InstallDownloadFailureLine -Line $failureLine[-1] -ExpectedRef 'main' -ExpectedCategory 'CorruptArchive'
+            $failure.Category | Should -Be 'CorruptArchive'
+        }
+        finally {
+            if ($server) { Stop-InstallArchiveServer -Server $server }
+            if (Test-Path -LiteralPath $caseRoot) {
+                Remove-Item -LiteralPath $caseRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/contract/Install.DownloadFailure.CorruptArchive.Tests.ps1
+++ b/tests/contract/Install.DownloadFailure.CorruptArchive.Tests.ps1
@@ -36,7 +36,7 @@ Describe 'Installer download failure categorization: corrupt archive' {
 
             $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref 'main'
 
-            $result.ExitCode | Should -Not -Be 0
+            $result.ExitCode | Should -Be 20
 
             $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
             $failureLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+download\s+failure\s+' }

--- a/tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1
+++ b/tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1
@@ -1,0 +1,43 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+
+Describe 'Installer download failure categorization: network unavailable' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-netfail-'
+        $script:BaseUrl = 'http://127.0.0.1:9/albt'
+        $script:Ref = 'main'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'emits NetworkUnavailable category when connection cannot be established' {
+        $destRoot = Join-Path $script:WorkspaceRoot ("repo-" + [Guid]::NewGuid().ToString('N'))
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        try {
+            $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $script:BaseUrl -Ref $script:Ref
+
+            $result.ExitCode | Should -Not -Be 0
+
+            $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+            $failureLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+download\s+failure\s+' }
+            $failureLine | Should -Not -BeNullOrEmpty
+
+            $failure = Assert-InstallDownloadFailureLine -Line $failureLine[-1] -ExpectedRef $script:Ref -ExpectedCategory 'NetworkUnavailable'
+            $failure.Category | Should -Be 'NetworkUnavailable'
+        }
+        finally {
+            if (Test-Path -LiteralPath $dest) {
+                Remove-Item -LiteralPath $dest -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1
+++ b/tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1
@@ -31,7 +31,7 @@ Describe 'Installer download failure categorization: network unavailable' {
             $failureLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+download\s+failure\s+' }
             $failureLine | Should -Not -BeNullOrEmpty
 
-            $failure = Assert-InstallDownloadFailureLine -Line $failureLine[-1] -ExpectedRef $script:Ref -ExpectedCategory 'NetworkUnavailable'
+            $failure = Assert-InstallDownloadFailureLine -Line $failureLine -ExpectedRef $script:Ref -ExpectedCategory 'NetworkUnavailable'
             $failure.Category | Should -Be 'NetworkUnavailable'
         }
         finally {

--- a/tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1
+++ b/tests/contract/Install.DownloadFailure.NetworkUnavailable.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'Installer download failure categorization: network unavailable' {
         try {
             $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $script:BaseUrl -Ref $script:Ref
 
-            $result.ExitCode | Should -Not -Be 0
+            $result.ExitCode | Should -Be 20
 
             $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
             $failureLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+download\s+failure\s+' }

--- a/tests/contract/Install.DownloadFailure.NotFound.Tests.ps1
+++ b/tests/contract/Install.DownloadFailure.NotFound.Tests.ps1
@@ -34,7 +34,7 @@ Describe 'Installer download failure categorization: not found' {
             $missingRef = 'missing-' + [Guid]::NewGuid().ToString('N')
             $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref $missingRef
 
-            $result.ExitCode | Should -Not -Be 0
+            $result.ExitCode | Should -Be 20
 
             $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
             $failureLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+download\s+failure\s+' }

--- a/tests/contract/Install.DownloadFailure.NotFound.Tests.ps1
+++ b/tests/contract/Install.DownloadFailure.NotFound.Tests.ps1
@@ -1,0 +1,53 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'InstallArchiveServer.psm1') -Force
+
+Describe 'Installer download failure categorization: not found' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-notfound-'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'emits NotFound category when archive endpoint returns 404' {
+        $caseRoot = Join-Path $script:WorkspaceRoot ("case-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $caseRoot | Out-Null
+
+        $destRoot = Join-Path $caseRoot 'repo'
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        $archiveWorkspace = Join-Path $caseRoot 'pkg'
+        $archive = New-InstallArchive -RepoRoot $script:RepoRoot -Workspace $archiveWorkspace
+
+        $server = $null
+        try {
+            $server = Start-InstallArchiveServer -ZipPath $archive.ZipPath -BasePath ('albt-' + [Guid]::NewGuid().ToString('N')) -StatusCode 404
+
+            $missingRef = 'missing-' + [Guid]::NewGuid().ToString('N')
+            $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref $missingRef
+
+            $result.ExitCode | Should -Not -Be 0
+
+            $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+            $failureLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+download\s+failure\s+' }
+            $failureLine | Should -Not -BeNullOrEmpty
+
+            $failure = Assert-InstallDownloadFailureLine -Line $failureLine[-1] -ExpectedRef $missingRef -ExpectedCategory 'NotFound'
+            $failure.Category | Should -Be 'NotFound'
+        }
+        finally {
+            if ($server) { Stop-InstallArchiveServer -Server $server }
+            if (Test-Path -LiteralPath $caseRoot) {
+                Remove-Item -LiteralPath $caseRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/contract/Install.DownloadFailure.NotFound.Tests.ps1
+++ b/tests/contract/Install.DownloadFailure.NotFound.Tests.ps1
@@ -40,7 +40,7 @@ Describe 'Installer download failure categorization: not found' {
             $failureLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+download\s+failure\s+' }
             $failureLine | Should -Not -BeNullOrEmpty
 
-            $failure = Assert-InstallDownloadFailureLine -Line $failureLine[-1] -ExpectedRef $missingRef -ExpectedCategory 'NotFound'
+            $failure = Assert-InstallDownloadFailureLine -Line $failureLine -ExpectedRef $missingRef -ExpectedCategory 'NotFound'
             $failure.Category | Should -Be 'NotFound'
         }
         finally {

--- a/tests/contract/Install.DownloadFailure.Timeout.Tests.ps1
+++ b/tests/contract/Install.DownloadFailure.Timeout.Tests.ps1
@@ -1,0 +1,22 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+
+Describe 'Installer download failure categorization: timeout' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-timeout-'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'emits Timeout category when download stalls beyond configured threshold' -Pending {
+        # Placeholder until timeout harness exists (FR-014).
+    }
+}

--- a/tests/contract/Install.GitRepoRequired.Tests.ps1
+++ b/tests/contract/Install.GitRepoRequired.Tests.ps1
@@ -62,7 +62,7 @@ Describe 'Installer guard: Git repository required' {
         try {
             $result = Invoke-TestInstall -Dest $dest
 
-            $result.ExitCode | Should -Not -Be 0
+            $result.ExitCode | Should -Be 10
 
             $lines = @()
             if ($result.StdOut) { $lines += $result.StdOut -split "(`r`n|`n)" }

--- a/tests/contract/Install.GitRepoRequired.Tests.ps1
+++ b/tests/contract/Install.GitRepoRequired.Tests.ps1
@@ -1,0 +1,83 @@
+#requires -Version 7.0
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+
+Describe 'Installer guard: Git repository required' {
+    BeforeAll {
+        $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $InstallScript = Join-Path $RepoRoot 'bootstrap' 'install.ps1'
+        $GuardBypassUrl = 'https://127.0.0.1:65535/al-build-tools'
+        $WorkspaceRoot = Join-Path ([IO.Path]::GetTempPath()) ("albt-gitrepo-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $WorkspaceRoot | Out-Null
+
+        function Invoke-TestInstall {
+            param(
+                [Parameter(Mandatory)] [string] $Dest
+            )
+
+            $psi = [System.Diagnostics.ProcessStartInfo]::new()
+            $psi.FileName = 'pwsh'
+            $psi.WorkingDirectory = $RepoRoot
+            $psi.RedirectStandardOutput = $true
+            $psi.RedirectStandardError = $true
+            $psi.UseShellExecute = $false
+
+            $null = $psi.ArgumentList.Add('-NoLogo')
+            $null = $psi.ArgumentList.Add('-NoProfile')
+            $null = $psi.ArgumentList.Add('-File')
+            $null = $psi.ArgumentList.Add($InstallScript)
+            $null = $psi.ArgumentList.Add('-Dest')
+            $null = $psi.ArgumentList.Add($Dest)
+            $null = $psi.ArgumentList.Add('-Url')
+            $null = $psi.ArgumentList.Add($GuardBypassUrl)
+            $null = $psi.ArgumentList.Add('-Ref')
+            $null = $psi.ArgumentList.Add('main')
+            $null = $psi.ArgumentList.Add('-Source')
+            $null = $psi.ArgumentList.Add('overlay')
+
+            $proc = [System.Diagnostics.Process]::Start($psi)
+            $proc.WaitForExit()
+
+            $stdout = $proc.StandardOutput.ReadToEnd()
+            $stderr = $proc.StandardError.ReadToEnd()
+
+            return [pscustomobject]@{
+                ExitCode = $proc.ExitCode
+                StdOut   = $stdout
+                StdErr   = $stderr
+            }
+        }
+    }
+
+    AfterAll {
+        if (Test-Path $WorkspaceRoot) {
+            Remove-Item -LiteralPath $WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'fails with GitRepoRequired guard when destination lacks git metadata' {
+        $dest = Join-Path $WorkspaceRoot ("dest-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $dest | Out-Null
+
+        try {
+            $result = Invoke-TestInstall -Dest $dest
+
+            $result.ExitCode | Should -Not -Be 0
+
+            $lines = @()
+            if ($result.StdOut) { $lines += $result.StdOut -split "(`r`n|`n)" }
+            if ($result.StdErr) { $lines += $result.StdErr -split "(`r`n|`n)" }
+            $lines = $lines | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
+            $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }
+            $guardLine | Should -Not -BeNullOrEmpty
+
+            $null = Assert-InstallGuardLine -Line $guardLine[0] -ExpectedGuard 'GitRepoRequired'
+        }
+        finally {
+            if (Test-Path $dest) {
+                Remove-Item -LiteralPath $dest -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/contract/Install.GitRepoRequired.Tests.ps1
+++ b/tests/contract/Install.GitRepoRequired.Tests.ps1
@@ -72,7 +72,7 @@ Describe 'Installer guard: Git repository required' {
             $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }
             $guardLine | Should -Not -BeNullOrEmpty
 
-            $null = Assert-InstallGuardLine -Line $guardLine[0] -ExpectedGuard 'GitRepoRequired'
+            $null = Assert-InstallGuardLine -Line $guardLine -ExpectedGuard 'GitRepoRequired'
         }
         finally {
             if (Test-Path $dest) {

--- a/tests/contract/Install.NonCleanAfterPartialFailure.Tests.ps1
+++ b/tests/contract/Install.NonCleanAfterPartialFailure.Tests.ps1
@@ -33,7 +33,7 @@ Describe 'Installer guard: refuse rerun when working tree dirty after partial fa
             $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }
             $guardLine | Should -Not -BeNullOrEmpty
 
-            $guard = Assert-InstallGuardLine -Line $guardLine[0] -ExpectedGuard 'WorkingTreeNotClean'
+            $guard = Assert-InstallGuardLine -Line $guardLine -ExpectedGuard 'WorkingTreeNotClean'
             $guard.Guard | Should -Be 'WorkingTreeNotClean'
         }
         finally {

--- a/tests/contract/Install.NonCleanAfterPartialFailure.Tests.ps1
+++ b/tests/contract/Install.NonCleanAfterPartialFailure.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'Installer guard: refuse rerun when working tree dirty after partial fa
         try {
             $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest
 
-            $result.ExitCode | Should -Not -Be 0
+            $result.ExitCode | Should -Be 10
 
             $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
             $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }

--- a/tests/contract/Install.NonCleanAfterPartialFailure.Tests.ps1
+++ b/tests/contract/Install.NonCleanAfterPartialFailure.Tests.ps1
@@ -1,0 +1,45 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+
+Describe 'Installer guard: refuse rerun when working tree dirty after partial failure' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-partial-'
+        $script:OverlaySampleFile = Join-Path $script:RepoRoot 'overlay' 'Makefile'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'fails with WorkingTreeNotClean guard when overlay residue exists from prior run' {
+        $destRoot = Join-Path $script:WorkspaceRoot ("repo-" + [Guid]::NewGuid().ToString('N'))
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        $overlayCopyTarget = Join-Path $dest 'Makefile'
+        Copy-Item -LiteralPath $script:OverlaySampleFile -Destination $overlayCopyTarget -Force
+
+        try {
+            $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest
+
+            $result.ExitCode | Should -Not -Be 0
+
+            $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+            $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }
+            $guardLine | Should -Not -BeNullOrEmpty
+
+            $guard = Assert-InstallGuardLine -Line $guardLine[0] -ExpectedGuard 'WorkingTreeNotClean'
+            $guard.Guard | Should -Be 'WorkingTreeNotClean'
+        }
+        finally {
+            if (Test-Path -LiteralPath $dest) {
+                Remove-Item -LiteralPath $dest -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/contract/Install.PowerShellVersionUnsupported.Tests.ps1
+++ b/tests/contract/Install.PowerShellVersionUnsupported.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'Installer guard: PowerShell version must be supported' {
             $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }
             $guardLine | Should -Not -BeNullOrEmpty
 
-            $guard = Assert-InstallGuardLine -Line $guardLine[0] -ExpectedGuard 'PowerShellVersionUnsupported'
+            $guard = Assert-InstallGuardLine -Line $guardLine -ExpectedGuard 'PowerShellVersionUnsupported'
             $guard.Guard | Should -Be 'PowerShellVersionUnsupported'
         }
         finally {

--- a/tests/contract/Install.PowerShellVersionUnsupported.Tests.ps1
+++ b/tests/contract/Install.PowerShellVersionUnsupported.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Installer guard: PowerShell version must be supported' {
             $envVars = @{ 'ALBT_TEST_FORCE_PSVERSION' = '5.1.0' }
             $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Environment $envVars
 
-            $result.ExitCode | Should -Not -Be 0
+            $result.ExitCode | Should -Be 10
 
             $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
             $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }

--- a/tests/contract/Install.PowerShellVersionUnsupported.Tests.ps1
+++ b/tests/contract/Install.PowerShellVersionUnsupported.Tests.ps1
@@ -1,0 +1,42 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+
+Describe 'Installer guard: PowerShell version must be supported' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-psver-'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'fails with PowerShellVersionUnsupported guard when simulated version is below requirement' {
+        $destRoot = Join-Path $script:WorkspaceRoot ("repo-" + [Guid]::NewGuid().ToString('N'))
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        try {
+            $envVars = @{ 'ALBT_TEST_FORCE_PSVERSION' = '5.1.0' }
+            $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Environment $envVars
+
+            $result.ExitCode | Should -Not -Be 0
+
+            $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+            $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }
+            $guardLine | Should -Not -BeNullOrEmpty
+
+            $guard = Assert-InstallGuardLine -Line $guardLine[0] -ExpectedGuard 'PowerShellVersionUnsupported'
+            $guard.Guard | Should -Be 'PowerShellVersionUnsupported'
+        }
+        finally {
+            if (Test-Path -LiteralPath $dest) {
+                Remove-Item -LiteralPath $dest -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/contract/Install.RestrictedWrites.Tests.ps1
+++ b/tests/contract/Install.RestrictedWrites.Tests.ps1
@@ -1,0 +1,70 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'InstallArchiveServer.psm1') -Force
+
+Describe 'Installer guard: restricted writes to overlay scope' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:OverlayRoot = Join-Path $script:RepoRoot 'overlay'
+        $script:OverlaySnapshot = Get-InstallDirectorySnapshot -Path $script:OverlayRoot -BasePath $script:OverlayRoot
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-restrict-'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'writes only overlay-managed files into the destination' {
+        $caseRoot = Join-Path $script:WorkspaceRoot ("case-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $caseRoot | Out-Null
+
+        $destRoot = Join-Path $caseRoot 'repo'
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        $archiveWorkspace = Join-Path $caseRoot 'pkg'
+        $archive = New-InstallArchive -RepoRoot $script:RepoRoot -Workspace $archiveWorkspace
+
+        $server = $null
+        try {
+            $before = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest
+
+            $server = Start-InstallArchiveServer -ZipPath $archive.ZipPath -BasePath ('albt-' + [Guid]::NewGuid().ToString('N'))
+            $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref 'main'
+
+            $result.ExitCode | Should -Be 0
+
+            $after = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest
+
+            $expectedPaths = $script:OverlaySnapshot | ForEach-Object { $_.Path }
+            $actualOverlay = $after | Where-Object { $expectedPaths -contains $_.Path }
+            Assert-InstallSnapshotsEqual -Expected $script:OverlaySnapshot -Actual $actualOverlay -Because 'Overlay copy deviated from repository overlay contents.'
+
+            $beforeMap = @{}
+            foreach ($item in $before) { $beforeMap[$item.Path] = $item }
+
+            $changedPaths = @()
+            foreach ($item in $after) {
+                if ($beforeMap.ContainsKey($item.Path)) {
+                    if ($beforeMap[$item.Path].Hash -ne $item.Hash) { $changedPaths += $item.Path }
+                } else {
+                    $changedPaths += $item.Path
+                }
+            }
+
+            foreach ($path in $changedPaths) {
+                $expectedPaths | Should -Contain $path
+            }
+        }
+        finally {
+            if ($server) { Stop-InstallArchiveServer -Server $server }
+            if (Test-Path -LiteralPath $caseRoot) {
+                Remove-Item -LiteralPath $caseRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/contract/Install.UnknownParameter.Tests.ps1
+++ b/tests/contract/Install.UnknownParameter.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Installer guard: unknown parameters must be rejected with guidance' {
         try {
             $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -AdditionalArguments @('-Nope123')
 
-            $result.ExitCode | Should -Not -Be 0
+            $result.ExitCode | Should -Be 10
 
             $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
             $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }

--- a/tests/contract/Install.UnknownParameter.Tests.ps1
+++ b/tests/contract/Install.UnknownParameter.Tests.ps1
@@ -1,0 +1,43 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+
+Describe 'Installer guard: unknown parameters must be rejected with guidance' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-arg-'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'fails with UnknownParameter guard when unsupported argument is provided' {
+        $destRoot = Join-Path $script:WorkspaceRoot ("repo-" + [Guid]::NewGuid().ToString('N'))
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        try {
+            $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -AdditionalArguments @('-Nope123')
+
+            $result.ExitCode | Should -Not -Be 0
+
+            $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+            $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }
+            $guardLine | Should -Not -BeNullOrEmpty
+
+            $guard = Assert-InstallGuardLine -Line $guardLine[0] -ExpectedGuard 'UnknownParameter'
+            $guard.Guard | Should -Be 'UnknownParameter'
+            $guard.Pairs.Contains('argument') | Should -BeTrue
+            $guard.Pairs['argument'] | Should -Be 'Nope123'
+        }
+        finally {
+            if (Test-Path -LiteralPath $dest) {
+                Remove-Item -LiteralPath $dest -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/contract/Install.UnknownParameter.Tests.ps1
+++ b/tests/contract/Install.UnknownParameter.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'Installer guard: unknown parameters must be rejected with guidance' {
             $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }
             $guardLine | Should -Not -BeNullOrEmpty
 
-            $guard = Assert-InstallGuardLine -Line $guardLine[0] -ExpectedGuard 'UnknownParameter'
+            $guard = Assert-InstallGuardLine -Line $guardLine -ExpectedGuard 'UnknownParameter'
             $guard.Guard | Should -Be 'UnknownParameter'
             $guard.Pairs.Contains('argument') | Should -BeTrue
             $guard.Pairs['argument'] | Should -Be 'Nope123'

--- a/tests/contract/Install.WorkingTreeNotClean.Tests.ps1
+++ b/tests/contract/Install.WorkingTreeNotClean.Tests.ps1
@@ -35,7 +35,7 @@ Describe 'Installer guard: Working tree must be clean' {
             $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }
             $guardLine | Should -Not -BeNullOrEmpty
 
-            $guard = Assert-InstallGuardLine -Line $guardLine[0] -ExpectedGuard 'WorkingTreeNotClean'
+            $guard = Assert-InstallGuardLine -Line $guardLine -ExpectedGuard 'WorkingTreeNotClean'
             $guard.Guard | Should -Be 'WorkingTreeNotClean'
         }
         finally {

--- a/tests/contract/Install.WorkingTreeNotClean.Tests.ps1
+++ b/tests/contract/Install.WorkingTreeNotClean.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'Installer guard: Working tree must be clean' {
         try {
             $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest
 
-            $result.ExitCode | Should -Not -Be 0
+            $result.ExitCode | Should -Be 10
 
             $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
             $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }

--- a/tests/contract/Install.WorkingTreeNotClean.Tests.ps1
+++ b/tests/contract/Install.WorkingTreeNotClean.Tests.ps1
@@ -1,0 +1,47 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+
+Describe 'Installer guard: Working tree must be clean' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-dirty-'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'fails with WorkingTreeNotClean guard when repo has uncommitted changes' {
+        $destRoot = Join-Path $script:WorkspaceRoot ("repo-" + [Guid]::NewGuid().ToString('N'))
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        $trackedFile = Join-Path $dest 'README.md'
+        Set-Content -Path $trackedFile -Value 'updated baseline for dirty state'
+
+        $untrackedFile = Join-Path $dest 'scratch.tmp'
+        Set-Content -Path $untrackedFile -Value 'untracked change'
+
+        try {
+            $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest
+
+            $result.ExitCode | Should -Not -Be 0
+
+            $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+            $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }
+            $guardLine | Should -Not -BeNullOrEmpty
+
+            $guard = Assert-InstallGuardLine -Line $guardLine[0] -ExpectedGuard 'WorkingTreeNotClean'
+            $guard.Guard | Should -Be 'WorkingTreeNotClean'
+        }
+        finally {
+            if (Test-Path -LiteralPath $dest) {
+                Remove-Item -LiteralPath $dest -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/contract/ShowConfig.Tests.ps1
+++ b/tests/contract/ShowConfig.Tests.ps1
@@ -1,32 +1,9 @@
 #requires -Version 7.0
 
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+
 Describe 'Show-config normalized key ordering (T010)' {
     BeforeAll {
-        function Invoke-ChildPwsh {
-            param(
-                [Parameter(Mandatory)] [string] $ScriptPath,
-                [string] $Arguments,
-                [string] $WorkingDirectory,
-                [hashtable] $Env
-            )
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = "pwsh"
-            $psi.Arguments = "-NoLogo -NoProfile -File `"$ScriptPath`" $Arguments"
-            if ($WorkingDirectory) { $psi.WorkingDirectory = $WorkingDirectory }
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            if ($Env) {
-                foreach ($k in $Env.Keys) { $psi.Environment[$k] = [string]$Env[$k] }
-            }
-            $proc = [System.Diagnostics.Process]::Start($psi)
-            $proc.WaitForExit()
-            $exit = $proc.ExitCode
-            $outStr = $proc.StandardOutput.ReadToEnd()
-            $errStr = $proc.StandardError.ReadToEnd()
-            return [pscustomobject]@{ ExitCode = $exit; StdOut = $outStr; StdErr = $errStr }
-        }
-
         $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
         $OverlayMake = Join-Path $RepoRoot 'overlay/scripts/make'
 

--- a/tests/contract/Verbosity.Tests.ps1
+++ b/tests/contract/Verbosity.Tests.ps1
@@ -1,39 +1,9 @@
 #requires -Version 7.0
 
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+
 Describe 'Verbosity behavior via env flag and -Verbose' {
     BeforeAll {
-        function Invoke-ChildPwsh {
-            param(
-                [Parameter(Mandatory)] [string] $ScriptPath,
-                [string] $Arguments,
-                [string] $WorkingDirectory,
-                [hashtable] $Env,
-                [switch] $EngineVerbose
-            )
-            $psi = New-Object System.Diagnostics.ProcessStartInfo
-            $psi.FileName = 'pwsh'
-            if ($EngineVerbose) {
-                # Use -Command to force verbose preference on in child scope
-                $cmd = "& { `$VerbosePreference = 'Continue'; & `"$ScriptPath`" $Arguments }"
-                $psi.Arguments = "-NoLogo -NoProfile -Command $cmd"
-            } else {
-                $psi.Arguments = "-NoLogo -NoProfile -File `"$ScriptPath`" $Arguments"
-            }
-            if ($WorkingDirectory) { $psi.WorkingDirectory = $WorkingDirectory }
-            $psi.RedirectStandardOutput = $true
-            $psi.RedirectStandardError = $true
-            $psi.UseShellExecute = $false
-            if ($Env) {
-                foreach ($k in $Env.Keys) { $psi.Environment[$k] = [string]$Env[$k] }
-            }
-            $proc = [System.Diagnostics.Process]::Start($psi)
-            $proc.WaitForExit()
-            $exit = $proc.ExitCode
-            $outStr = $proc.StandardOutput.ReadToEnd()
-            $errStr = $proc.StandardError.ReadToEnd()
-            return [pscustomobject]@{ ExitCode = $exit; StdOut = $outStr; StdErr = $errStr }
-        }
-
         $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
         $OverlayMake = Join-Path $RepoRoot 'overlay/scripts/make'
         $Tmp = Join-Path ([IO.Path]::GetTempPath()) ("albt-verbosity-" + [Guid]::NewGuid().ToString('N'))

--- a/tests/integration/Install.EnvironmentIsolation.Tests.ps1
+++ b/tests/integration/Install.EnvironmentIsolation.Tests.ps1
@@ -43,7 +43,7 @@ Describe 'Installer environment isolation' {
                 $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
                 $successLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }
                 $successLine | Should -Not -BeNullOrEmpty
-                $success = Assert-InstallSuccessLine -Line $successLine[0] -ExpectedRef 'main' -ExpectedOverlay 'overlay'
+                $success = Assert-InstallSuccessLine -Line $successLine -ExpectedRef 'main' -ExpectedOverlay 'overlay'
 
                 $tempLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+temp\s+' }
                 $tempLine | Should -Not -BeNullOrEmpty

--- a/tests/integration/Install.EnvironmentIsolation.Tests.ps1
+++ b/tests/integration/Install.EnvironmentIsolation.Tests.ps1
@@ -1,0 +1,102 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'InstallArchiveServer.psm1') -Force
+
+Describe 'Installer environment isolation' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:OverlayRoot = Join-Path $script:RepoRoot 'overlay'
+        $script:OverlaySnapshot = Get-InstallDirectorySnapshot -Path $script:OverlayRoot -BasePath $script:OverlayRoot
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-iso-'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'handles sequential installs in separate repos without cross-contamination' {
+        $caseRoot = Join-Path $script:WorkspaceRoot ("case-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $caseRoot | Out-Null
+
+        $archiveWorkspace = Join-Path $caseRoot 'pkg'
+        $archive = New-InstallArchive -RepoRoot $script:RepoRoot -Workspace $archiveWorkspace
+
+        $server = $null
+        $runs = @()
+        try {
+            $server = Start-InstallArchiveServer -ZipPath $archive.ZipPath -BasePath ('albt-' + [Guid]::NewGuid().ToString('N'))
+
+            for ($i = 1; $i -le 2; $i++) {
+                $destRoot = Join-Path $caseRoot ("repo-" + $i)
+                $dest = Initialize-InstallTestRepo -Path $destRoot
+
+                $before = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest
+
+                $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref 'main'
+                $result.ExitCode | Should -Be 0
+
+                $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+                $successLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }
+                $successLine | Should -Not -BeNullOrEmpty
+                $success = Assert-InstallSuccessLine -Line $successLine[0] -ExpectedRef 'main' -ExpectedOverlay 'overlay'
+
+                $tempLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+temp\s+' }
+                $tempLine | Should -Not -BeNullOrEmpty
+                $temp = Assert-InstallTempLine -Line $tempLine[-1]
+                Test-Path -LiteralPath $temp.Workspace | Should -BeFalse
+
+                $after = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest
+
+                $runs += [pscustomobject]@{
+                    Dest = $dest
+                    Before = $before
+                    After = $after
+                    Success = $success
+                    Temp = $temp
+                }
+            }
+
+            $runs.Count | Should -Be 2
+
+            $expectedPaths = $script:OverlaySnapshot | ForEach-Object { $_.Path }
+            foreach ($run in $runs) {
+                $actualOverlay = $run.After | Where-Object { $expectedPaths -contains $_.Path }
+                Assert-InstallSnapshotsEqual -Expected $script:OverlaySnapshot -Actual $actualOverlay -Because 'Installed overlay does not match repository overlay.'
+
+                $beforeMap = @{}
+                foreach ($item in $run.Before) { $beforeMap[$item.Path] = $item }
+
+                $changedPaths = @()
+                foreach ($item in $run.After) {
+                    if ($beforeMap.ContainsKey($item.Path)) {
+                        if ($beforeMap[$item.Path].Hash -ne $item.Hash) { $changedPaths += $item.Path }
+                    } else {
+                        $changedPaths += $item.Path
+                    }
+                }
+
+                foreach ($path in $changedPaths) {
+                    $expectedPaths | Should -Contain $path
+                }
+            }
+
+            $uniqueTemps = $runs | ForEach-Object { $_.Temp.Workspace } | Sort-Object -Unique
+            $uniqueTemps.Count | Should -Be $runs.Count
+
+            $firstAfter = $runs[0].After
+            $firstFinal = Get-InstallDirectorySnapshot -Path $runs[0].Dest -BasePath $runs[0].Dest
+            Assert-InstallSnapshotsEqual -Expected $firstAfter -Actual $firstFinal -Because 'First install changed after running second install.'
+        }
+        finally {
+            if ($server) { Stop-InstallArchiveServer -Server $server }
+            if (Test-Path -LiteralPath $caseRoot) {
+                Remove-Item -LiteralPath $caseRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/integration/Install.EnvironmentIsolation.Tests.ps1
+++ b/tests/integration/Install.EnvironmentIsolation.Tests.ps1
@@ -47,7 +47,7 @@ Describe 'Installer environment isolation' {
 
                 $tempLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+temp\s+' }
                 $tempLine | Should -Not -BeNullOrEmpty
-                $temp = Assert-InstallTempLine -Line $tempLine[-1]
+                $temp = Assert-InstallTempLine -Line $tempLine
                 Test-Path -LiteralPath $temp.Workspace | Should -BeFalse
 
                 $after = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest

--- a/tests/integration/Install.IdempotentOverwrite.Tests.ps1
+++ b/tests/integration/Install.IdempotentOverwrite.Tests.ps1
@@ -41,7 +41,7 @@ Describe 'Installer success path: idempotent overwrite' {
             $firstLines = Get-InstallOutputLines -StdOut $first.StdOut -StdErr $first.StdErr
             $firstSuccess = $firstLines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }
             $firstSuccess | Should -Not -BeNullOrEmpty
-            $null = Assert-InstallSuccessLine -Line $firstSuccess[0] -ExpectedRef 'main' -ExpectedOverlay 'overlay' -MaxDurationSeconds 120
+            $null = Assert-InstallSuccessLine -Line $firstSuccess -ExpectedRef 'main' -ExpectedOverlay 'overlay' -MaxDurationSeconds 120
 
             $afterFirst = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest
             $expectedPaths = $script:OverlaySnapshot | ForEach-Object { $_.Path }
@@ -57,7 +57,7 @@ Describe 'Installer success path: idempotent overwrite' {
             $secondLines = Get-InstallOutputLines -StdOut $second.StdOut -StdErr $second.StdErr
             $secondSuccess = $secondLines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }
             $secondSuccess | Should -Not -BeNullOrEmpty
-            $null = Assert-InstallSuccessLine -Line $secondSuccess[0] -ExpectedRef 'main' -ExpectedOverlay 'overlay' -MaxDurationSeconds 120
+            $null = Assert-InstallSuccessLine -Line $secondSuccess -ExpectedRef 'main' -ExpectedOverlay 'overlay' -MaxDurationSeconds 120
 
             $afterSecond = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest
             $actualOverlaySecond = $afterSecond | Where-Object { $expectedPaths -contains $_.Path }

--- a/tests/integration/Install.IdempotentOverwrite.Tests.ps1
+++ b/tests/integration/Install.IdempotentOverwrite.Tests.ps1
@@ -51,6 +51,10 @@ Describe 'Installer success path: idempotent overwrite' {
             $tamperPath = Join-Path $dest $script:TamperTarget
             Test-Path -LiteralPath $tamperPath | Should -BeTrue
             Set-Content -LiteralPath $tamperPath -Value 'tampered content' -NoNewline
+            
+            # Commit the tampered file to keep working tree clean for second install
+            & git -C $dest add .
+            & git -C $dest commit -m 'Tamper with overlay file for idempotence test' | Out-Null
 
             $second = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref 'main'
             $second.ExitCode | Should -Be 0

--- a/tests/integration/Install.IdempotentOverwrite.Tests.ps1
+++ b/tests/integration/Install.IdempotentOverwrite.Tests.ps1
@@ -1,0 +1,95 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'InstallArchiveServer.psm1') -Force
+
+Describe 'Installer success path: idempotent overwrite' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $overlayRoot = Join-Path $script:RepoRoot 'overlay'
+        $script:OverlaySnapshot = Get-InstallDirectorySnapshot -Path $overlayRoot -BasePath $overlayRoot
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-idem-'
+        $script:TamperTarget = 'Makefile'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'restores modified overlay files on subsequent runs' {
+        $caseRoot = Join-Path $script:WorkspaceRoot ("case-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $caseRoot | Out-Null
+
+        $destRoot = Join-Path $caseRoot 'repo'
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        $archiveWorkspace = Join-Path $caseRoot 'pkg'
+        $archive = New-InstallArchive -RepoRoot $script:RepoRoot -Workspace $archiveWorkspace
+
+        $server = $null
+        try {
+            $before = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest
+
+            $server = Start-InstallArchiveServer -ZipPath $archive.ZipPath -BasePath ('albt-' + [Guid]::NewGuid().ToString('N'))
+
+            $first = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref 'main'
+            $first.ExitCode | Should -Be 0
+            $firstLines = Get-InstallOutputLines -StdOut $first.StdOut -StdErr $first.StdErr
+            $firstSuccess = $firstLines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }
+            $firstSuccess | Should -Not -BeNullOrEmpty
+            $null = Assert-InstallSuccessLine -Line $firstSuccess[0] -ExpectedRef 'main' -ExpectedOverlay 'overlay' -MaxDurationSeconds 120
+
+            $afterFirst = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest
+            $expectedPaths = $script:OverlaySnapshot | ForEach-Object { $_.Path }
+            $actualOverlay = $afterFirst | Where-Object { $expectedPaths -contains $_.Path }
+            Assert-InstallSnapshotsEqual -Expected $script:OverlaySnapshot -Actual $actualOverlay -Because 'Initial install overlay mismatch.'
+
+            $tamperPath = Join-Path $dest $script:TamperTarget
+            Test-Path -LiteralPath $tamperPath | Should -BeTrue
+            Set-Content -LiteralPath $tamperPath -Value 'tampered content' -NoNewline
+
+            $second = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref 'main'
+            $second.ExitCode | Should -Be 0
+            $secondLines = Get-InstallOutputLines -StdOut $second.StdOut -StdErr $second.StdErr
+            $secondSuccess = $secondLines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }
+            $secondSuccess | Should -Not -BeNullOrEmpty
+            $null = Assert-InstallSuccessLine -Line $secondSuccess[0] -ExpectedRef 'main' -ExpectedOverlay 'overlay' -MaxDurationSeconds 120
+
+            $afterSecond = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest
+            $actualOverlaySecond = $afterSecond | Where-Object { $expectedPaths -contains $_.Path }
+            Assert-InstallSnapshotsEqual -Expected $script:OverlaySnapshot -Actual $actualOverlaySecond -Because 'Second install overlay mismatch.'
+
+            $tamperBaseline = $script:OverlaySnapshot | Where-Object { $_.Path -eq $script:TamperTarget }
+            $tamperBaseline | Should -Not -BeNullOrEmpty
+            $tamperedActual = $afterSecond | Where-Object { $_.Path -eq $script:TamperTarget }
+            $tamperedActual | Should -Not -BeNullOrEmpty
+            $tamperedActual[0].Hash | Should -Be $tamperBaseline[0].Hash
+
+            $beforeMap = @{}
+            foreach ($item in $before) { $beforeMap[$item.Path] = $item }
+
+            $changedPaths = @()
+            foreach ($item in $afterSecond) {
+                if ($beforeMap.ContainsKey($item.Path)) {
+                    if ($beforeMap[$item.Path].Hash -ne $item.Hash) { $changedPaths += $item.Path }
+                } else {
+                    $changedPaths += $item.Path
+                }
+            }
+
+            foreach ($path in $changedPaths) {
+                $expectedPaths | Should -Contain $path
+            }
+        }
+        finally {
+            if ($server) { Stop-InstallArchiveServer -Server $server }
+            if (Test-Path -LiteralPath $caseRoot) {
+                Remove-Item -LiteralPath $caseRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/integration/Install.NoWritesOnFailure.Tests.ps1
+++ b/tests/integration/Install.NoWritesOnFailure.Tests.ps1
@@ -1,0 +1,53 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'InstallArchiveServer.psm1') -Force
+
+Describe 'Installer failure isolation: no writes when download fails' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-fail-'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'keeps destination unchanged when archive download never succeeds' {
+        $caseRoot = Join-Path $script:WorkspaceRoot ("case-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $caseRoot | Out-Null
+
+        $destRoot = Join-Path $caseRoot 'repo'
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        $archiveWorkspace = Join-Path $caseRoot 'pkg'
+        $archive = New-InstallArchive -RepoRoot $script:RepoRoot -Workspace $archiveWorkspace
+
+        $server = $null
+        try {
+            $before = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest
+
+            $server = Start-InstallArchiveServer -ZipPath $archive.ZipPath -BasePath ('albt-' + [Guid]::NewGuid().ToString('N')) -StatusCode 404
+            $invalidRef = 'missing-ref-' + [Guid]::NewGuid().ToString('N')
+            $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref $invalidRef
+
+            $result.ExitCode | Should -Not -Be 0
+
+            $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+            ($lines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }) | Should -BeNullOrEmpty
+
+            $after = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest
+            Assert-InstallSnapshotsEqual -Expected $before -Actual $after -Because 'Destination changed after failed install.'
+        }
+        finally {
+            if ($server) { Stop-InstallArchiveServer -Server $server }
+            if (Test-Path -LiteralPath $caseRoot) {
+                Remove-Item -LiteralPath $caseRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/integration/Install.NoWritesOnFailure.Tests.ps1
+++ b/tests/integration/Install.NoWritesOnFailure.Tests.ps1
@@ -35,7 +35,7 @@ Describe 'Installer failure isolation: no writes when download fails' {
             $invalidRef = 'missing-ref-' + [Guid]::NewGuid().ToString('N')
             $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref $invalidRef
 
-            $result.ExitCode | Should -Not -Be 0
+            $result.ExitCode | Should -Be 20
 
             $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
             ($lines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }) | Should -BeNullOrEmpty

--- a/tests/integration/Install.Parity.Structure.Tests.ps1
+++ b/tests/integration/Install.Parity.Structure.Tests.ps1
@@ -1,0 +1,109 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'InstallArchiveServer.psm1') -Force
+
+function Parse-InstallStepLine {
+    param([string] $Line)
+
+    $pattern = '^[[]install[]]\s+step\s+(?<Pairs>.+)$'
+    $match = [regex]::Match($Line, $pattern)
+    if (-not $match.Success) {
+        throw "Line '$Line' does not match '[install] step' pattern."
+    }
+
+    $pairsText = $match.Groups['Pairs'].Value
+    $pairs = @{}
+    foreach ($segment in $pairsText -split '\s+') {
+        if ([string]::IsNullOrWhiteSpace($segment)) { continue }
+        if ($segment -notmatch '^(?<Key>[A-Za-z0-9_-]+)=(?<Value>.+)$') {
+            throw "Segment '$segment' from '$Line' is not in key=value format."
+        }
+
+        $key = $Matches['Key']
+        $value = $Matches['Value']
+        $pairs[$key] = $value
+    }
+
+    foreach ($required in @('index','name')) {
+        if (-not $pairs.ContainsKey($required)) {
+            throw "Step diagnostic '$Line' missing required token '$required'."
+        }
+    }
+
+    $index = 0
+    if (-not [int]::TryParse($pairs['index'], [ref]$index)) {
+        throw "Step index '$($pairs['index'])' from '$Line' is not an integer."
+    }
+
+    $name = $pairs['name']
+    if ($name -notmatch '^[A-Za-z0-9_-]+$') {
+        throw "Step name '$name' contains invalid characters for parity expectations."
+    }
+
+    return [pscustomobject]@{
+        Index = $index
+        Name = $name
+        Pairs = $pairs
+        RawLine = $Line
+    }
+}
+
+Describe 'Installer parity structure' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-parity-'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'emits sequential [install] step diagnostics with portable names' {
+        $caseRoot = Join-Path $script:WorkspaceRoot ("case-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $caseRoot | Out-Null
+
+        $destRoot = Join-Path $caseRoot 'repo'
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        $archiveWorkspace = Join-Path $caseRoot 'pkg'
+        $archive = New-InstallArchive -RepoRoot $script:RepoRoot -Workspace $archiveWorkspace
+
+        $server = $null
+        try {
+            $server = Start-InstallArchiveServer -ZipPath $archive.ZipPath -BasePath ('albt-' + [Guid]::NewGuid().ToString('N'))
+            $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref 'main'
+
+            $result.ExitCode | Should -Be 0
+
+            $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+            $stepLines = $lines | Where-Object { $_ -match '^[[]install[]]\s+step\s+' }
+            $stepLines | Should -Not -BeNullOrEmpty
+
+            $parsed = $stepLines | ForEach-Object { Parse-InstallStepLine -Line $_ }
+            ($parsed | Measure-Object).Count | Should -BeGreaterThanOrEqual 4
+
+            $ordered = $parsed | Sort-Object -Property Index
+            for ($i = 0; $i -lt $ordered.Count; $i++) {
+                $expectedIndex = $i + 1
+                $ordered[$i].Index | Should -Be $expectedIndex
+            }
+
+            $names = $ordered | ForEach-Object { $_.Name }
+            foreach ($name in $names) {
+                $name.Contains('/') | Should -BeFalse
+                $name.Contains('\') | Should -BeFalse
+            }
+        }
+        finally {
+            if ($server) { Stop-InstallArchiveServer -Server $server }
+            if (Test-Path -LiteralPath $caseRoot) {
+                Remove-Item -LiteralPath $caseRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/integration/Install.Parity.Structure.Tests.ps1
+++ b/tests/integration/Install.Parity.Structure.Tests.ps1
@@ -5,52 +5,6 @@ Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -F
 Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
 Import-Module (Join-Path $PSScriptRoot '..' '_install' 'InstallArchiveServer.psm1') -Force
 
-function Parse-InstallStepLine {
-    param([string] $Line)
-
-    $pattern = '^[[]install[]]\s+step\s+(?<Pairs>.+)$'
-    $match = [regex]::Match($Line, $pattern)
-    if (-not $match.Success) {
-        throw "Line '$Line' does not match '[install] step' pattern."
-    }
-
-    $pairsText = $match.Groups['Pairs'].Value
-    $pairs = @{}
-    foreach ($segment in $pairsText -split '\s+') {
-        if ([string]::IsNullOrWhiteSpace($segment)) { continue }
-        if ($segment -notmatch '^(?<Key>[A-Za-z0-9_-]+)=(?<Value>.+)$') {
-            throw "Segment '$segment' from '$Line' is not in key=value format."
-        }
-
-        $key = $Matches['Key']
-        $value = $Matches['Value']
-        $pairs[$key] = $value
-    }
-
-    foreach ($required in @('index','name')) {
-        if (-not $pairs.ContainsKey($required)) {
-            throw "Step diagnostic '$Line' missing required token '$required'."
-        }
-    }
-
-    $index = 0
-    if (-not [int]::TryParse($pairs['index'], [ref]$index)) {
-        throw "Step index '$($pairs['index'])' from '$Line' is not an integer."
-    }
-
-    $name = $pairs['name']
-    if ($name -notmatch '^[A-Za-z0-9_-]+$') {
-        throw "Step name '$name' contains invalid characters for parity expectations."
-    }
-
-    return [pscustomobject]@{
-        Index = $index
-        Name = $name
-        Pairs = $pairs
-        RawLine = $Line
-    }
-}
-
 Describe 'Installer parity structure' {
     BeforeAll {
         $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
@@ -86,47 +40,8 @@ Describe 'Installer parity structure' {
 
             $parsed = @()
             foreach ($line in $stepLines) {
-                $pattern = '^[[]install[]]\s+step\s+(?<Pairs>.+)$'
-                $match = [regex]::Match($line, $pattern)
-                if (-not $match.Success) {
-                    throw "Line '$line' does not match '[install] step' pattern."
-                }
-
-                $pairsText = $match.Groups['Pairs'].Value
-                $pairs = @{}
-                foreach ($segment in $pairsText -split '\s+') {
-                    if ([string]::IsNullOrWhiteSpace($segment)) { continue }
-                    if ($segment -notmatch '^(?<Key>[A-Za-z0-9_-]+)=(?<Value>.+)$') {
-                        throw "Segment '$segment' from '$line' is not in key=value format."
-                    }
-
-                    $key = $Matches['Key']
-                    $value = $Matches['Value']
-                    $pairs[$key] = $value
-                }
-
-                foreach ($required in @('index','name')) {
-                    if (-not $pairs.ContainsKey($required)) {
-                        throw "Step diagnostic '$line' missing required token '$required'."
-                    }
-                }
-
-                $index = 0
-                if (-not [int]::TryParse($pairs['index'], [ref]$index)) {
-                    throw "Step index '$($pairs['index'])' from '$line' is not an integer."
-                }
-
-                $name = $pairs['name']
-                if ($name -notmatch '^[A-Za-z0-9_-]+$') {
-                    throw "Step name '$name' contains invalid characters for parity expectations."
-                }
-
-                $parsed += [pscustomobject]@{
-                    Index = $index
-                    Name = $name
-                    Pairs = $pairs
-                    RawLine = $line
-                }
+                $stepInfo = Assert-InstallStepLine -Line $line
+                $parsed += $stepInfo
             }
             
             if ($parsed.Count -lt 4) {

--- a/tests/integration/Install.PerformanceBudget.Tests.ps1
+++ b/tests/integration/Install.PerformanceBudget.Tests.ps1
@@ -1,0 +1,60 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'InstallArchiveServer.psm1') -Force
+
+Describe 'Installer performance budget' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-perf-'
+        $script:WarningThresholdSeconds = 25
+        $script:FailThresholdSeconds = 30
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'completes within the documented performance budget' {
+        $caseRoot = Join-Path $script:WorkspaceRoot ("case-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $caseRoot | Out-Null
+
+        $destRoot = Join-Path $caseRoot 'repo'
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        $archiveWorkspace = Join-Path $caseRoot 'pkg'
+        $archive = New-InstallArchive -RepoRoot $script:RepoRoot -Workspace $archiveWorkspace
+
+        $server = $null
+        try {
+            $server = Start-InstallArchiveServer -ZipPath $archive.ZipPath -BasePath ('albt-' + [Guid]::NewGuid().ToString('N'))
+            $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref 'main'
+
+            $result.ExitCode | Should -Be 0
+
+            $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+            $successLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }
+            $successLine | Should -Not -BeNullOrEmpty
+
+            $success = Assert-InstallSuccessLine -Line $successLine[0] -ExpectedRef 'main' -ExpectedOverlay 'overlay'
+            $duration = $success.DurationSeconds
+            $duration | Should -BeGreaterThanOrEqual 0
+
+            if ($duration -gt $script:WarningThresholdSeconds) {
+                Write-Warning ("Installer duration {0:N2}s exceeded warning threshold {1}s" -f $duration, $script:WarningThresholdSeconds)
+            }
+
+            $duration | Should -BeLessThan $script:FailThresholdSeconds
+        }
+        finally {
+            if ($server) { Stop-InstallArchiveServer -Server $server }
+            if (Test-Path -LiteralPath $caseRoot) {
+                Remove-Item -LiteralPath $caseRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/integration/Install.PerformanceBudget.Tests.ps1
+++ b/tests/integration/Install.PerformanceBudget.Tests.ps1
@@ -40,7 +40,7 @@ Describe 'Installer performance budget' {
             $successLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }
             $successLine | Should -Not -BeNullOrEmpty
 
-            $success = Assert-InstallSuccessLine -Line $successLine[0] -ExpectedRef 'main' -ExpectedOverlay 'overlay'
+            $success = Assert-InstallSuccessLine -Line $successLine -ExpectedRef 'main' -ExpectedOverlay 'overlay'
             $duration = $success.DurationSeconds
             $duration | Should -BeGreaterThanOrEqual 0
 

--- a/tests/integration/Install.PermissionDenied.Tests.ps1
+++ b/tests/integration/Install.PermissionDenied.Tests.ps1
@@ -1,0 +1,80 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'InstallArchiveServer.psm1') -Force
+
+Describe 'Installer guard: permission denied protection' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-perm-'
+        $script:TargetRelativePath = 'Makefile'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'fails with PermissionDenied guard when overlay contains read-only files' {
+        $caseRoot = Join-Path $script:WorkspaceRoot ("case-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $caseRoot | Out-Null
+
+        $destRoot = Join-Path $caseRoot 'repo'
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        $archiveWorkspace = Join-Path $caseRoot 'pkg'
+        $archive = New-InstallArchive -RepoRoot $script:RepoRoot -Workspace $archiveWorkspace
+
+        $server = $null
+        try {
+            $server = Start-InstallArchiveServer -ZipPath $archive.ZipPath -BasePath ('albt-' + [Guid]::NewGuid().ToString('N'))
+
+            $first = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref 'main'
+            $first.ExitCode | Should -Be 0
+
+            $targetPath = Join-Path $dest $script:TargetRelativePath
+            Test-Path -LiteralPath $targetPath | Should -BeTrue
+
+            if ($IsWindows) {
+                $fileInfo = Get-Item -LiteralPath $targetPath -ErrorAction Stop
+                $fileInfo.IsReadOnly = $true
+            } else {
+                & chmod 400 -- $targetPath
+            }
+
+            try {
+                $second = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref 'main'
+
+                $second.ExitCode | Should -Not -Be 0
+
+                $lines = Get-InstallOutputLines -StdOut $second.StdOut -StdErr $second.StdErr
+                $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }
+                $guardLine | Should -Not -BeNullOrEmpty
+
+                $guard = Assert-InstallGuardLine -Line $guardLine[0] -ExpectedGuard 'PermissionDenied'
+                $guard.Guard | Should -Be 'PermissionDenied'
+
+                ($lines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }) | Should -BeNullOrEmpty
+            }
+            finally {
+                if (Test-Path -LiteralPath $targetPath) {
+                    if ($IsWindows) {
+                        $fileInfo = Get-Item -LiteralPath $targetPath -ErrorAction SilentlyContinue
+                        if ($fileInfo) { $fileInfo.IsReadOnly = $false }
+                    } else {
+                        & chmod 600 -- $targetPath 2>$null
+                    }
+                }
+            }
+        }
+        finally {
+            if ($server) { Stop-InstallArchiveServer -Server $server }
+            if (Test-Path -LiteralPath $caseRoot) {
+                Remove-Item -LiteralPath $caseRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/integration/Install.PermissionDenied.Tests.ps1
+++ b/tests/integration/Install.PermissionDenied.Tests.ps1
@@ -43,7 +43,7 @@ Describe 'Installer guard: permission denied protection' {
 
             $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref 'main'
 
-            $result.ExitCode | Should -Not -Be 0
+            $result.ExitCode | Should -Be 30
 
             $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
             $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }

--- a/tests/integration/Install.PermissionDenied.Tests.ps1
+++ b/tests/integration/Install.PermissionDenied.Tests.ps1
@@ -54,7 +54,7 @@ Describe 'Installer guard: permission denied protection' {
                 $guardLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+guard\s+' }
                 $guardLine | Should -Not -BeNullOrEmpty
 
-                $guard = Assert-InstallGuardLine -Line $guardLine[0] -ExpectedGuard 'PermissionDenied'
+                $guard = Assert-InstallGuardLine -Line $guardLine -ExpectedGuard 'PermissionDenied'
                 $guard.Guard | Should -Be 'PermissionDenied'
 
                 ($lines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }) | Should -BeNullOrEmpty

--- a/tests/integration/Install.Success.Basic.Tests.ps1
+++ b/tests/integration/Install.Success.Basic.Tests.ps1
@@ -1,0 +1,75 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'InstallArchiveServer.psm1') -Force
+
+Describe 'Installer success path: basic overlay install' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $overlayRoot = Join-Path $script:RepoRoot 'overlay'
+        $script:OverlaySnapshot = Get-InstallDirectorySnapshot -Path $overlayRoot -BasePath $overlayRoot
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-success-'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'installs overlay files and reports success diagnostics' {
+        $caseRoot = Join-Path $script:WorkspaceRoot ("case-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $caseRoot | Out-Null
+
+        $destRoot = Join-Path $caseRoot 'repo'
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        $archiveWorkspace = Join-Path $caseRoot 'pkg'
+        $archive = New-InstallArchive -RepoRoot $script:RepoRoot -Workspace $archiveWorkspace
+
+        $server = $null
+        try {
+            $before = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest
+
+            $server = Start-InstallArchiveServer -ZipPath $archive.ZipPath -BasePath ('albt-' + [Guid]::NewGuid().ToString('N'))
+            $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref 'main'
+
+            $result.ExitCode | Should -Be 0
+
+            $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+            $successLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }
+            $successLine | Should -Not -BeNullOrEmpty
+
+            $null = Assert-InstallSuccessLine -Line $successLine[0] -ExpectedRef 'main' -ExpectedOverlay 'overlay' -MaxDurationSeconds 120
+
+            $after = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest
+            $expectedPaths = $script:OverlaySnapshot | ForEach-Object { $_.Path }
+            $actualOverlay = $after | Where-Object { $expectedPaths -contains $_.Path }
+            Assert-InstallSnapshotsEqual -Expected $script:OverlaySnapshot -Actual $actualOverlay -Because 'Installed overlay does not match repository overlay.'
+
+            $beforeMap = @{}
+            foreach ($item in $before) { $beforeMap[$item.Path] = $item }
+
+            $changedPaths = @()
+            foreach ($item in $after) {
+                if ($beforeMap.ContainsKey($item.Path)) {
+                    if ($beforeMap[$item.Path].Hash -ne $item.Hash) { $changedPaths += $item.Path }
+                } else {
+                    $changedPaths += $item.Path
+                }
+            }
+
+            foreach ($path in $changedPaths) {
+                $expectedPaths | Should -Contain $path
+            }
+        }
+        finally {
+            if ($server) { Stop-InstallArchiveServer -Server $server }
+            if (Test-Path -LiteralPath $caseRoot) {
+                Remove-Item -LiteralPath $caseRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/integration/Install.Success.Basic.Tests.ps1
+++ b/tests/integration/Install.Success.Basic.Tests.ps1
@@ -42,7 +42,7 @@ Describe 'Installer success path: basic overlay install' {
             $successLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }
             $successLine | Should -Not -BeNullOrEmpty
 
-            $null = Assert-InstallSuccessLine -Line $successLine[0] -ExpectedRef 'main' -ExpectedOverlay 'overlay' -MaxDurationSeconds 120
+            $null = Assert-InstallSuccessLine -Line $successLine -ExpectedRef 'main' -ExpectedOverlay 'overlay' -MaxDurationSeconds 120
 
             $after = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest
             $expectedPaths = $script:OverlaySnapshot | ForEach-Object { $_.Path }

--- a/tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1
+++ b/tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1
@@ -38,7 +38,7 @@ Describe 'Installer temp workspace lifecycle' {
             $tempLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+temp\s+' }
             $tempLine | Should -Not -BeNullOrEmpty
 
-            $tempInfo = Assert-InstallTempLine -Line $tempLine[-1]
+            $tempInfo = Assert-InstallTempLine -Line $tempLine
             $tempInfo.Workspace | Should -Not -BeNullOrEmpty
 
             Test-Path -LiteralPath $tempInfo.Workspace | Should -BeFalse

--- a/tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1
+++ b/tests/integration/Install.TempWorkspaceLifecycle.Tests.ps1
@@ -1,0 +1,56 @@
+#requires -Version 7.0
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Assert-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'Invoke-Install.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot '..' '_install' 'InstallArchiveServer.psm1') -Force
+
+Describe 'Installer temp workspace lifecycle' {
+    BeforeAll {
+        $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+        $script:WorkspaceRoot = New-InstallTestWorkspace -Prefix 'albt-temp-'
+    }
+
+    AfterAll {
+        if ($script:WorkspaceRoot -and (Test-Path -LiteralPath $script:WorkspaceRoot)) {
+            Remove-Item -LiteralPath $script:WorkspaceRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'reports temp workspace path and removes it after completion' {
+        $caseRoot = Join-Path $script:WorkspaceRoot ("case-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $caseRoot | Out-Null
+
+        $destRoot = Join-Path $caseRoot 'repo'
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        $archiveWorkspace = Join-Path $caseRoot 'pkg'
+        $archive = New-InstallArchive -RepoRoot $script:RepoRoot -Workspace $archiveWorkspace
+
+        $server = $null
+        try {
+            $server = Start-InstallArchiveServer -ZipPath $archive.ZipPath -BasePath ('albt-' + [Guid]::NewGuid().ToString('N'))
+            $result = Invoke-InstallScript -RepoRoot $script:RepoRoot -Dest $dest -Url $server.BaseUrl -Ref 'main'
+
+            $result.ExitCode | Should -Be 0
+
+            $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+            $tempLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+temp\s+' }
+            $tempLine | Should -Not -BeNullOrEmpty
+
+            $tempInfo = Assert-InstallTempLine -Line $tempLine[-1]
+            $tempInfo.Workspace | Should -Not -BeNullOrEmpty
+
+            Test-Path -LiteralPath $tempInfo.Workspace | Should -BeFalse
+
+            $successLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }
+            $successLine | Should -Not -BeNullOrEmpty
+        }
+        finally {
+            if ($server) { Stop-InstallArchiveServer -Server $server }
+            if (Test-Path -LiteralPath $caseRoot) {
+                Remove-Item -LiteralPath $caseRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}


### PR DESCRIPTION
Refactor the permission denied test to properly handle ACLs on both
Windows and Unix systems. This ensures that write access is denied
correctly and restores original permissions after the test completes.