### PR TITLE
Enhance installer asset handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A minimal, cross-platform build toolkit for Microsoft AL projects with a dead-simple bootstrap. It is designed to be dropped into an existing git repo and updated by running the same single command again.
 
-Install and update are the same: the bootstrap resolves a published GitHub release, downloads its `overlay.zip` asset, and copies everything from the archive’s `overlay/` folder into your project. Because you’re in git, you review and commit changes as you like.
+Install and update are the same: the bootstrap resolves a published GitHub release, downloads its overlay ZIP asset (it prefers `overlay.zip` and falls back to `al-build-tools-<tag>.zip` for legacy releases), and copies everything from the archive’s `overlay/` folder into your project. Because you’re in git, you review and commit changes as you like.
 
 ## Quick Start (Install Latest Release)
 
@@ -138,7 +138,7 @@ When updating `bootstrap/install.ps1`, adjust `specs/005-add-tests-for/traceabil
 - Trigger the `Manual Overlay Release` GitHub Actions workflow whenever you are ready to ship a tagged overlay-only archive.
 - Provide `version`, `summary`, and `dry_run` inputs; the workflow enforces semantic version monotonicity, tag uniqueness, and overlay cleanliness before packaging.
 - Run a dry pass (`dry_run=true`) to preview the staged overlay file list, SHA-256 manifest, metadata JSON block, and diff summary without creating a tag or release.
-- Run a publish pass (`dry_run=false`) to create the `vMAJOR.MINOR.PATCH` tag, upload `al-build-tools-<version>.zip`, and embed both the manifest and metadata block in the release notes.
+- Run a publish pass (`dry_run=false`) to create the `vMAJOR.MINOR.PATCH` tag, upload the overlay ZIP (`overlay.zip` going forward; legacy releases use `al-build-tools-<version>.zip`), and embed both the manifest and metadata block in the release notes.
 - Consumers can verify archives by expanding the ZIP, running `sha256sum -c manifest.sha256.txt` (or the PowerShell equivalent), and matching the `root_hash` and `commit` fields reported in the release metadata.
 - For step-by-step maintainer and consumer checklists, see [specs/006-manual-release-workflow/quickstart.md](specs/006-manual-release-workflow/quickstart.md).
 
@@ -146,7 +146,7 @@ When updating `bootstrap/install.ps1`, adjust `specs/005-add-tests-for/traceabil
 ## How It Works
 
 1. Resolves the effective release tag using the selection order above.
-2. Downloads the `overlay.zip` asset from the chosen GitHub release (using the releases API).
+2. Downloads the overlay ZIP asset (`overlay.zip` when present, otherwise `al-build-tools-<tag>.zip`) from the chosen GitHub release (using the releases API).
 3. Copies `overlay/*` into your destination directory, overwriting existing files.
 4. No state files and no backups — use git to review and commit changes.
 

--- a/specs/007-description-i-want/contracts/install-diagnostics.md
+++ b/specs/007-description-i-want/contracts/install-diagnostics.md
@@ -4,7 +4,7 @@ Only release-driven installs are supported; diagnostics below assume the install
 
 ## Success Log
 - **Trigger**: `Install-AlBuildTools` completes copy of `overlay/` from selected release.
-- **Output**: `[install] success ref="<resolved-tag>" overlay="overlay" asset="overlay.zip" duration=<seconds>`
+- **Output**: `[install] success ref="<resolved-tag>" overlay="overlay" asset="<asset-name>" duration=<seconds>` (e.g., `overlay.zip` or `al-build-tools-<tag>.zip`)
 - **Acceptance**:
   - `resolved-tag` equals the canonical release tag returned by GitHub.
   - `asset` field matches the downloaded asset name.

--- a/specs/007-description-i-want/data-model.md
+++ b/specs/007-description-i-want/data-model.md
@@ -6,6 +6,6 @@ This feature does not introduce persistent application data or new entities beyo
 |--------|--------|-------------|
 | `EffectiveSelector` | `SourceRef` (input parameter), `EnvOverride` (`ALBT_RELEASE`), `ResolvedTag` (canonical tag) | Represents the precedence chain that yields the release tag used for lookup. |
 | `ReleaseMetadata` | `TagName`, `IsDraft`, `IsPrerelease`, `PublishedAt`, `Assets[]` | Payload returned by the GitHub Releases API. Only published releases with non-empty assets are accepted. |
-| `ReleaseAsset` | `Id`, `Name`, `DownloadUrl` | Asset descriptor used to fetch the overlay zip. The installer expects a single asset named `overlay.zip`. |
+| `ReleaseAsset` | `Id`, `Name`, `DownloadUrl` | Asset descriptor used to fetch the overlay zip. The installer prefers an asset named `overlay.zip` but can fall back to legacy `al-build-tools-<tag>.zip` packages. |
 
 All structures remain transient within the script execution and are not exposed outside of the installer process. Branch/tarball archive descriptors are intentionally absent—release metadata is the sole supported install surface.

--- a/specs/007-description-i-want/quickstart.md
+++ b/specs/007-description-i-want/quickstart.md
@@ -3,7 +3,7 @@
 > Installs now communicate exclusively with GitHub release APIs—legacy branch archive URLs no longer succeed by design.
 
 1. Create a disposable git repository and ensure the working tree is clean.
-2. Publish or identify two GitHub releases for `FBakkensen/al-build-tools` that each contain an `overlay.zip` asset.
+2. Publish or identify two GitHub releases for `FBakkensen/al-build-tools` that each contain an overlay ZIP asset (`overlay.zip` or legacy `al-build-tools-<tag>.zip`).
 3. Run `pwsh -File bootstrap/install.ps1 -Dest <repo> -Source overlay` without specifying `-Ref` and confirm the script reports the latest release tag in the success diagnostic.
 4. Export `ALBT_RELEASE=<older-tag>` and rerun the installer without `-Ref`; verify the reported release matches the environment override.
 5. Invoke `pwsh -File bootstrap/install.ps1 -Ref <older-tag-without-v>` and confirm the installer normalizes and reports the canonical `v`-prefixed tag.

--- a/specs/007-description-i-want/research.md
+++ b/specs/007-description-i-want/research.md
@@ -34,5 +34,5 @@
   - Merging both inputs (env as default, parameter appended to diagnostics) → invites confusion and contradicts spec direction.
 
 ## Open Verification Items
-- Confirm the release pipeline publishes a single asset named `overlay.zip` that contains the expected root folder.
+- Confirm the release pipeline publishes a single overlay ZIP asset (`overlay.zip` preferred; legacy `al-build-tools-<tag>.zip` remains supported) that contains the expected root folder.
 - Validate GitHub API rate limits are acceptable for installer usage (unauthenticated limit of 60 requests/hour should suffice, but note in README for heavy automation).

--- a/tests/integration/Install.ReleaseSelection.Latest.Tests.ps1
+++ b/tests/integration/Install.ReleaseSelection.Latest.Tests.ps1
@@ -86,4 +86,67 @@ Describe 'Installer release selection: latest published release' {
             }
         }
     }
+
+    It 'falls back to versioned asset names when overlay.zip is missing' {
+        $caseRoot = Join-Path $script:WorkspaceRoot ("case-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $caseRoot | Out-Null
+
+        $destRoot = Join-Path $caseRoot 'repo'
+        $dest = Initialize-InstallTestRepo -Path $destRoot
+
+        $archiveWorkspace = Join-Path $caseRoot 'pkg'
+        if (-not (Test-Path -LiteralPath $archiveWorkspace)) {
+            New-Item -ItemType Directory -Path $archiveWorkspace | Out-Null
+        }
+        $latestTag = 'v3.0.0'
+        $latestAssetName = 'al-build-tools-v3.0.0.zip'
+        $latestArchive = New-InstallArchive -RepoRoot $script:RepoRoot -Workspace (Join-Path $archiveWorkspace 'latest') -Ref $latestTag
+
+        $server = $null
+        try {
+            $releases = @(
+                [pscustomobject]@{
+                    Tag = $latestTag
+                    ZipPath = $latestArchive.ZipPath
+                    AssetName = $latestAssetName
+                    PublishedAt = (Get-Date).AddMinutes(-5)
+                }
+            )
+
+            $server = Start-InstallArchiveServer -BasePath ('albt-' + [Guid]::NewGuid().ToString('N')) -Releases $releases -LatestTag $latestTag
+
+            $before = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest
+
+            $scriptPath = Join-Path $script:RepoRoot 'bootstrap' 'install.ps1'
+            $arguments = "-Dest `"$dest`" -Url `"$($server.BaseUrl)`" -Source overlay"
+            $result = Invoke-ChildPwsh -ScriptPath $scriptPath -Arguments $arguments -WorkingDirectory $script:RepoRoot
+
+            $result.ExitCode | Should -Be 0
+
+            $lines = Get-InstallOutputLines -StdOut $result.StdOut -StdErr $result.StdErr
+            $successLine = $lines | Where-Object { $_ -match '^[[]install[]]\s+success\s+' }
+            $successLine | Should -Not -BeNullOrEmpty
+
+            $parsed = Assert-InstallSuccessLine -Line $successLine -ExpectedRef $latestTag -ExpectedOverlay 'overlay' -ExpectedAsset $latestAssetName -MaxDurationSeconds 300
+            $parsed.CanonicalRef | Should -Be $latestTag
+
+            $after = Get-InstallDirectorySnapshot -Path $dest -BasePath $dest
+            $expectedPaths = $script:OverlaySnapshot | ForEach-Object { $_.Path }
+            $actualOverlay = $after | Where-Object { $expectedPaths -contains $_.Path }
+            Assert-InstallSnapshotsEqual -Expected $script:OverlaySnapshot -Actual $actualOverlay -Because 'Installed overlay snapshot diverged from expected release contents.'
+
+            $beforeMap = @{}
+            foreach ($item in $before) { $beforeMap[$item.Path] = $item }
+            foreach ($item in $after) {
+                if ($beforeMap.ContainsKey($item.Path) -and $beforeMap[$item.Path].Hash -eq $item.Hash) { continue }
+                $expectedPaths | Should -Contain $item.Path
+            }
+        }
+        finally {
+            if ($server) { Stop-InstallArchiveServer -Server $server }
+            if (Test-Path -LiteralPath $caseRoot) {
+                Remove-Item -LiteralPath $caseRoot -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
 }


### PR DESCRIPTION
Update the installer to prefer 'overlay.zip' for asset downloads, with
a fallback to legacy 'al-build-tools-<tag>.zip' if necessary. This
improves compatibility with existing releases and ensures smoother
installation processes. Additionally, update documentation to reflect
these changes.