### PR TITLE
Improve error handling in installation script

### DIFF
--- a/bootstrap/install.ps1
+++ b/bootstrap/install.ps1
@@ -30,7 +30,7 @@ if ($unknownArgs.Count -gt 0) {
     $argName = if ($firstArg.StartsWith('-')) { $firstArg.Substring(1) } else { $firstArg }
     Write-Host "[install] guard UnknownParameter argument=`"$argName`""
     Write-Host "Usage: Install-AlBuildTools [-Url <url>] [-Ref <ref>] [-Dest <path>] [-Source <folder>]"
-    throw "Installation failed: Unknown parameter '$argName'. Use: Install-AlBuildTools [-Url <url>] [-Ref <ref>] [-Dest <path>] [-Source <folder>]"
+    Write-Error "Installation failed: Unknown parameter '$argName'. Use: Install-AlBuildTools [-Url <url>] [-Ref <ref>] [-Dest <path>] [-Source <folder>]"
 }
 
 function Write-Note($msg) { Write-Host "[al-build-tools] $msg" -ForegroundColor Cyan }
@@ -213,7 +213,7 @@ function Install-AlBuildTools {
     }
     if ($psVersion -lt [System.Version]'7.0') {
         Write-Host "[install] guard PowerShellVersionUnsupported"
-        throw "Installation failed: PowerShell 7.0 or later is required. Current version: $psVersion"
+        Write-Error "Installation failed: PowerShell 7.0 or later is required. Current version: $psVersion"
     }
 
     $effectiveTimeoutSec = $HttpTimeoutSec
@@ -259,7 +259,7 @@ function Install-AlBuildTools {
     # FR-023: Abort when destination is not a git repository
     if (-not $gitOk -and -not (Test-Path (Join-Path $destFull '.git'))) {
         Write-Host "[install] guard GitRepoRequired"
-        throw "Installation failed: Destination '$destFull' is not a git repository. Please initialize git first with 'git init' or clone an existing repository."
+        Write-Error "Installation failed: Destination '$destFull' is not a git repository. Please initialize git first with 'git init' or clone an existing repository."
     }
 
     # FR-024: Require clean working tree before copying overlay
@@ -276,7 +276,7 @@ function Install-AlBuildTools {
             $statusOutput = $p.StandardOutput.ReadToEnd().Trim()
             if (-not [string]::IsNullOrEmpty($statusOutput)) {
                 Write-Host "[install] guard WorkingTreeNotClean"
-                throw "Installation failed: Working tree is not clean. Please commit or stash your changes before running the installation."
+                Write-Error "Installation failed: Working tree is not clean. Please commit or stash your changes before running the installation."
             }
         }
     }
@@ -311,7 +311,7 @@ function Install-AlBuildTools {
 
         if ([string]::IsNullOrWhiteSpace($apiBase)) {
             Write-Host "[install] download failure ref=`"$refForFailure`" url=`"$Url`" category=Unknown hint=`"Release service URL is empty`""
-            throw "Installation failed: Release service URL is empty or invalid."
+            Write-Error "Installation failed: Release service URL is empty or invalid."
         }
 
         if ($selection.Tag) {
@@ -344,12 +344,12 @@ function Install-AlBuildTools {
         } catch {
             $failure = Resolve-DownloadFailureDetails -ErrorRecord $_ -DefaultHint 'Unable to retrieve release metadata' -StatusHints $metadataStatusHints
             Write-Host "[install] download failure ref=`"$refForFailure`" url=`"$releaseRequestUrl`" category=$($failure.Category) hint=`"$($failure.Hint)`""
-            throw "Installation failed: Unable to retrieve release metadata. $($failure.Hint)"
+            Write-Error "Installation failed: Unable to retrieve release metadata. $($failure.Hint)"
         }
 
         if ($null -eq $releaseMetadata) {
             Write-Host "[install] download failure ref=`"$refForFailure`" url=`"$releaseRequestUrl`" category=NotFound hint=`"Release metadata missing`""
-            throw "Installation failed: Release metadata is missing or invalid."
+            Write-Error "Installation failed: Release metadata is missing or invalid."
         }
 
         $selectedReleaseTag = ConvertTo-CanonicalReleaseTag -Tag ($releaseMetadata.tag_name)
@@ -358,13 +358,13 @@ function Install-AlBuildTools {
         }
         if (-not $selectedReleaseTag) {
             Write-Host "[install] download failure ref=`"$refForFailure`" url=`"$releaseRequestUrl`" category=Unknown hint=`"Release tag could not be determined`""
-            throw "Installation failed: Release tag could not be determined from the release metadata."
+            Write-Error "Installation failed: Release tag could not be determined from the release metadata."
         }
         $refForFailure = $selectedReleaseTag
 
         if ($releaseMetadata.draft -eq $true -or $releaseMetadata.prerelease -eq $true) {
             Write-Host "[install] download failure ref=`"$refForFailure`" url=`"$releaseRequestUrl`" category=NotFound hint=`"Release not published`""
-            throw "Installation failed: Release '$refForFailure' is not published (it may be a draft or prerelease)."
+            Write-Error "Installation failed: Release '$refForFailure' is not published (it may be a draft or prerelease)."
         }
 
         $assets = @()
@@ -402,7 +402,7 @@ function Install-AlBuildTools {
                 Write-Verbose "[install] asset fallback Using release asset '$(($fallbackAsset.name))'"
             } else {
                 Write-Host "[install] download failure ref=`"$refForFailure`" url=`"$releaseRequestUrl`" category=NotFound hint=`"Release asset overlay.zip not found`""
-                throw "Installation failed: Release asset 'overlay.zip' not found in release '$refForFailure'."
+                Write-Error "Installation failed: Release asset 'overlay.zip' not found in release '$refForFailure'."
             }
         }
 
@@ -418,7 +418,7 @@ function Install-AlBuildTools {
 
         if ([string]::IsNullOrWhiteSpace($assetDownloadUrl)) {
             Write-Host "[install] download failure ref=`"$refForFailure`" url=`"$releaseRequestUrl`" category=Unknown hint=`"Release asset download URL missing`""
-            throw "Installation failed: Release asset download URL is missing or invalid."
+            Write-Error "Installation failed: Release asset download URL is missing or invalid."
         }
 
         Write-Note "Selected release: $selectedReleaseTag (asset: $assetName)"
@@ -449,7 +449,7 @@ function Install-AlBuildTools {
         } catch {
             $failure = Resolve-DownloadFailureDetails -ErrorRecord $_ -DefaultHint 'Unable to download release asset' -StatusHints $assetStatusHints
             Write-Host "[install] download failure ref=`"$refForFailure`" url=`"$assetDownloadUrl`" category=$($failure.Category) hint=`"$($failure.Hint)`""
-            throw "Installation failed: Unable to download release asset. $($failure.Hint)"
+            Write-Error "Installation failed: Unable to download release asset. $($failure.Hint)"
         }
 
         $step++; Write-Step $step "Extract and locate '$Source'"
@@ -458,12 +458,12 @@ function Install-AlBuildTools {
             Expand-Archive -LiteralPath $zip -DestinationPath $extract -Force -ErrorAction Stop
         } catch {
             Write-Host "[install] download failure ref=`"$refForFailure`" url=`"$assetDownloadUrl`" category=CorruptArchive hint=`"Failed to extract asset`""
-            throw "Installation failed: Failed to extract the downloaded archive. The file may be corrupted."
+            Write-Error "Installation failed: Failed to extract the downloaded archive. The file may be corrupted."
         }
         $top = Get-ChildItem -Path $extract -Directory | Select-Object -First 1
         if (-not $top) {
             Write-Host "[install] download failure ref=`"$refForFailure`" url=`"$assetDownloadUrl`" category=CorruptArchive hint=`"Asset archive appears empty`""
-            throw "Installation failed: Downloaded archive appears to be empty or corrupted."
+            Write-Error "Installation failed: Downloaded archive appears to be empty or corrupted."
         }
         $src = Join-Path $top.FullName $Source
         if (-not (Test-Path $src -PathType Container)) {
@@ -472,13 +472,13 @@ function Install-AlBuildTools {
                 $src = $cand.FullName
             } else {
                 Write-Host "[install] download failure ref=`"$refForFailure`" url=`"$assetDownloadUrl`" category=NotFound hint=`"Source folder '$Source' not found in asset`""
-                throw "Installation failed: Source folder '$Source' not found in the downloaded archive."
+                Write-Error "Installation failed: Source folder '$Source' not found in the downloaded archive."
             }
         }
 
         if (-not (Get-ChildItem -Path $src -File -ErrorAction SilentlyContinue)) {
             Write-Host "[install] download failure ref=`"$refForFailure`" url=`"$assetDownloadUrl`" category=CorruptArchive hint=`"Source directory contains no files`""
-            throw "Installation failed: Source directory contains no files to install."
+            Write-Error "Installation failed: Source directory contains no files to install."
         }
 
         Write-Ok "Source directory: $src"
@@ -493,7 +493,7 @@ function Install-AlBuildTools {
             $resolvedTarget = [System.IO.Path]::GetFullPath($targetPath)
             if (-not $resolvedTarget.StartsWith($destFull, [System.StringComparison]::OrdinalIgnoreCase)) {
                 Write-Host "[install] guard RestrictedWrites"
-                throw "Installation failed: Security violation - attempt to write outside the destination directory."
+                Write-Error "Installation failed: Security violation - attempt to write outside the destination directory."
             }
         }
 
@@ -503,7 +503,7 @@ function Install-AlBuildTools {
             Copy-Item -Path (Join-Path $src '*') -Destination $destFull -Recurse -Force -ErrorAction Stop
         } catch [System.UnauthorizedAccessException], [System.IO.IOException] {
             Write-Host "[install] guard PermissionDenied"
-            throw "Installation failed: Permission denied. Please check that you have write permissions to the destination directory."
+            Write-Error "Installation failed: Permission denied. Please check that you have write permissions to the destination directory."
         }
         Write-Ok "Copied $fileCount files across $dirCount directories"
 
@@ -534,6 +534,6 @@ if ($PSCommandPath -and ($MyInvocation.InvocationName -ne '.') -and -not $env:AL
         Install-AlBuildTools @installParams
     } catch {
         Write-Host "[install] error unhandled=$(ConvertTo-Json $_.Exception.Message -Compress)"
-        throw "Installation failed: An unexpected error occurred during installation. $($_.Exception.Message)"
+        Write-Error "Installation failed: An unexpected error occurred during installation. $($_.Exception.Message)"
     }
 }


### PR DESCRIPTION
Replace throw statements with Write-Error for better error reporting
and consistency in the Install-AlBuildTools function. This change
enhances user feedback during installation failures.