### PR TITLE
fix(bootstrap): handle iex execution and Docker Dev Drive volume mounting

### DIFF
--- a/bootstrap/install.ps1
+++ b/bootstrap/install.ps1
@@ -13,7 +13,15 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 # Source prerequisite installer functions
-. "$PSScriptRoot/install-prerequisites.ps1"
+if ($PSScriptRoot) {
+    # Running as a file - dot-source from disk
+    . "$PSScriptRoot/install-prerequisites.ps1"
+} else {
+    # Running via iex (piped from web) - download and execute in memory
+    $prereqUrl = 'https://raw.githubusercontent.com/FBakkensen/al-build-tools/main/bootstrap/install-prerequisites.ps1'
+    $prereqScript = Invoke-WebRequest -Uri $prereqUrl -UseBasicParsing -ErrorAction Stop | Select-Object -ExpandProperty Content
+    Invoke-Expression $prereqScript
+}
 
 # Handle $IsWindows for PowerShell 5.1 compatibility (added in PS 6.0)
 if (-not (Get-Variable -Name 'IsWindows' -Scope Global -ErrorAction SilentlyContinue)) {


### PR DESCRIPTION
Business Context:
- Installer fails when piped via iex (one-liner distribution pattern: iwr | iex)
- CI tests fail on Dev Drive due to Docker Desktop 28.5.1 regression with ReFS volumes
- Both issues prevent users and CI from running bootstrap installer successfully

Technical Changes:
- Added conditional logic in bootstrap/install.ps1 to detect iex execution mode
- When PSScriptRoot is empty (iex mode), download install-prerequisites.ps1 from GitHub main branch
- Modified test-bootstrap-install.ps1 to copy bootstrap and testdata to C:\Users\<user>\AppData\Local\Temp before Docker mounting
- Ensures Docker volume mounts use standard NTFS volumes instead of Dev Drive ReFS

Implementation Details:
- bootstrap/install.ps1: Checks if PSScriptRoot exists; if yes, dot-source from disk; if no, download from GitHub and execute via Invoke-Expression
- test-bootstrap-install.ps1: Creates temp copies of bootstrap and testdata directories before building docker run arguments
- Copies preserve full directory structure recursively with -Force flag
- Updated Docker volume mount paths to use temp directories instead of source directories

Impact:
- Users can now run documented one-liner installer: iwr -useb https://raw.githubusercontent.com/FBakkensen/al-build-tools/main/bootstrap/install.ps1 | iex; Install-AlBuildTools -Dest .
- CI tests now pass locally on Windows 24H2 with Dev Drive repositories
- No impact on CI/CD workflows (GitHub-hosted runners use standard C: drive)
- Backward compatible: file-based execution unchanged

Files Changed:
- bootstrap/install.ps1 (modified): Added iex execution mode detection and fallback download logic
- scripts/ci/test-bootstrap-install.ps1 (modified): Added temp directory copy logic for Docker volume mounting